### PR TITLE
Convert more enarx -> virtee references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
-homepage = "https://github.com/enarx/sev"
-repository = "https://github.com/enarx/sev"
+homepage = "https://github.com/virtee/sev"
+repository = "https://github.com/virtee/sev"
 description = "Library for AMD SEV"
 readme = "README.md"
 keywords = ["amd", "sev"]
@@ -14,11 +14,11 @@ exclude = [ ".gitignore", ".github/*" ]
 
 [badges]
 # See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
-github = { repository = "enarx/sev", workflow = "test" }
-#github = { repository = "enarx/sev", workflow = "lint" }
+github = { repository = "virtee/sev", workflow = "test" }
+#github = { repository = "virtee/sev", workflow = "lint" }
 maintenance = { status = "actively-developed" }
-is-it-maintained-issue-resolution = { repository = "enarx/sev" }
-is-it-maintained-open-issues = { repository = "enarx/sev" }
+is-it-maintained-issue-resolution = { repository = "virtee/sev" }
+is-it-maintained-open-issues = { repository = "virtee/sev" }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Workflow Status](https://github.com/enarx/sev/workflows/test/badge.svg)](https://github.com/enarx/sev/actions?query=workflow%3A%22test%22)
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/sev.svg)](https://isitmaintained.com/project/enarx/sev "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/sev.svg)](https://isitmaintained.com/project/enarx/sev "Percentage of issues still open")
+[![Workflow Status](https://github.com/virtee/sev/workflows/test/badge.svg)](https://github.com/virtee/sev/actions?query=workflow%3A%22test%22)
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/virtee/sev.svg)](https://isitmaintained.com/project/virtee/sev "Average time to resolve an issue")
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/virtee/sev.svg)](https://isitmaintained.com/project/virtee/sev "Percentage of issues still open")
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 
 # sev


### PR DESCRIPTION
Cargo.toml and README.md badges still point to enarx github.
Switch them to virtee
