### PR TITLE
Expand std::io wildcard `use` declarations

### DIFF
--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -13,7 +13,7 @@ mod util;
 mod crypto;
 
 use std::convert::*;
-use std::io::*;
+use std::io::{Error, ErrorKind, Read, Result, Write};
 
 pub use chain::Chain;
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,7 +7,7 @@ mod key;
 
 use super::*;
 use openssl::*;
-use std::io::*;
+use std::io::{Error, ErrorKind, Result};
 
 /// Represents a brand-new secure channel with the AMD SP.
 pub struct Initialized;


### PR DESCRIPTION
std::io::* imports std::io::Chain.
The sev crate exports its own Chain.
This confuses the vscode rust-analyzer plugin.

Drop the wildcard and explicilty list every std::io bit the affected
files use. IMO this makes for more readable code too.
