### PR TITLE
vmsa API tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ codicon = "3.0"
 bitfield = "0.13"
 dirs = "4.0"
 iocuddle = "0.1"
-bincode = "1.3.3"
 serde-big-array = "0.4.1"
 
 [dev-dependencies]

--- a/src/vmsa/mod.rs
+++ b/src/vmsa/mod.rs
@@ -441,7 +441,9 @@ impl Vmsa {
         self.cs.base = u64::from(reset_cs);
     }
 
-    /// Read binary content from a passed filename and deserialize it into a VMSA struct.
+    /// Read binary content from a passed filename and deserialize it into a
+    /// VMSA struct. Validate that the passed file is 4096 bytes long,
+    /// which is expected by SEV measurement validation.
     pub fn from_file(filename: &str) -> Result<Self, io::Error> {
         let data = std::fs::read(filename)?;
         if data.len() != 4096 {
@@ -454,7 +456,9 @@ impl Vmsa {
         Ok(vmsa)
     }
 
-    /// Serialize a VMSA struct and write it to a passed filename.
+    /// Serialize a VMSA struct and write it to a passed filename,
+    /// This ensures it is padded to 4096 bytes which is expected
+    /// by SEV measurement validation.
     pub fn to_file(&self, filename: &str) -> Result<(), io::Error> {
         let mut vmsa_buf = Vec::new();
         self.encode(&mut vmsa_buf, ())?;

--- a/src/vmsa/mod.rs
+++ b/src/vmsa/mod.rs
@@ -444,6 +444,12 @@ impl Vmsa {
     /// Read binary content from a passed filename and deserialize it into a VMSA struct.
     pub fn from_file(filename: &str) -> Result<Self, io::Error> {
         let data = std::fs::read(filename)?;
+        if data.len() != 4096 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Expected VMSA length 4096, was {}", data.len()),
+            ));
+        }
         let vmsa = Vmsa::decode(&data[..], ())?;
         Ok(vmsa)
     }


### PR DESCRIPTION
This tweaks the newly added vmsa API to be a bit more consistent with other `sev` code

* Use standard io::Result and io::Error
* Use codicon encode and decode methods for serializing

This also added a VMSA file length check on file input, to match the padding we do when writing to file. See individual commit messages for more details.