### PR TITLE
session: allow verifying an external digest

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -204,6 +204,24 @@ impl Session<Measuring> {
 
         session.verify(&digest, build, msr)
     }
+
+    /// Verifies the session's measurement against the AMD SP's measurement
+    /// using an externally generated digest.
+    pub fn verify_with_digest(
+        self,
+        build: Build,
+        msr: launch::sev::Measurement,
+        digest: &[u8],
+    ) -> Result<Session<Verified>> {
+        let session = Session {
+            policy: self.policy,
+            tek: self.tek,
+            tik: self.tik,
+            data: Initialized,
+        };
+
+        session.verify(digest, build, msr)
+    }
 }
 
 impl Session<Verified> {


### PR DESCRIPTION
In some cases, such as when the digest of each launch measurement is
pre-generated beforehand, it's useful to be able to verify an
externally generated digest instead of having to pass the payload data
through Session<Measuring>::update_data().

This change implements Session<Measuring>::verify_with_digest(), which
behaves in the same way as Session<Measuring>::verify() but verifying
a digest that is provided as an argument to the method.

Signed-off-by: Sergio Lopez <slp@redhat.com>