### PR TITLE
Launch API trait cleanups

### DIFF
--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -33,13 +33,6 @@ pub struct Launcher<T> {
     sev: RawFd,
 }
 
-impl<T> Launcher<T> {
-    /// Give access to the vm fd to create vCPUs or such.
-    pub fn as_mut_vmfd(&mut self) -> &mut RawFd {
-        &mut self.vm_fd
-    }
-}
-
 impl Launcher<New> {
     /// Begin the SEV launch process.
     pub fn new(kvm: RawFd, sev: RawFd) -> Result<Self> {

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -12,7 +12,7 @@ use crate::*;
 
 use std::io::Result;
 use std::mem::MaybeUninit;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::RawFd;
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -27,41 +27,41 @@ pub struct Started(Handle);
 pub struct Measured(Handle, Measurement);
 
 /// Facilitates the correct execution of the SEV launch process.
-pub struct Launcher<'a, T, U: AsRawFd, V: AsRawFd> {
+pub struct Launcher<T> {
     state: T,
-    vm_fd: &'a mut U,
-    sev: &'a mut V,
+    vm_fd: RawFd,
+    sev: RawFd,
 }
 
-impl<'a, T, U: AsRawFd, V: AsRawFd> Launcher<'a, T, U, V> {
+impl<T> Launcher<T> {
     /// Give access to the vm fd to create vCPUs or such.
-    pub fn as_mut_vmfd(&mut self) -> &mut U {
-        self.vm_fd
+    pub fn as_mut_vmfd(&mut self) -> &mut RawFd {
+        &mut self.vm_fd
     }
 }
 
-impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, New, U, V> {
+impl Launcher<New> {
     /// Begin the SEV launch process.
-    pub fn new(kvm: &'a mut U, sev: &'a mut V) -> Result<Self> {
-        let launcher = Launcher {
+    pub fn new(kvm: RawFd, sev: RawFd) -> Result<Self> {
+        let mut launcher = Launcher {
             vm_fd: kvm,
             sev,
             state: New,
         };
 
-        let mut cmd = Command::from(launcher.sev, &Init);
-        INIT.ioctl(launcher.vm_fd, &mut cmd)
+        let mut cmd = Command::from(&mut launcher.sev, &Init);
+        INIT.ioctl(&mut launcher.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 
         Ok(launcher)
     }
 
     /// Create an encrypted guest context.
-    pub fn start(self, start: Start) -> Result<Launcher<'a, Started, U, V>> {
+    pub fn start(mut self, start: Start) -> Result<Launcher<Started>> {
         let mut launch_start = LaunchStart::new(&start.policy, &start.cert, &start.session);
-        let mut cmd = Command::from_mut(self.sev, &mut launch_start);
+        let mut cmd = Command::from_mut(&mut self.sev, &mut launch_start);
         LAUNCH_START
-            .ioctl(self.vm_fd, &mut cmd)
+            .ioctl(&mut self.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 
         let next = Launcher {
@@ -74,28 +74,28 @@ impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, New, U, V> {
     }
 }
 
-impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Started, U, V> {
+impl Launcher<Started> {
     /// Encrypt guest data with its VEK.
     pub fn update_data(&mut self, data: &[u8]) -> Result<()> {
         let launch_update_data = LaunchUpdateData::new(data);
-        let mut cmd = Command::from(self.sev, &launch_update_data);
+        let mut cmd = Command::from(&mut self.sev, &launch_update_data);
 
-        KvmEncRegion::new(data).register(self.vm_fd)?;
+        KvmEncRegion::new(data).register(&mut self.vm_fd)?;
 
         LAUNCH_UPDATE_DATA
-            .ioctl(self.vm_fd, &mut cmd)
+            .ioctl(&mut self.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 
         Ok(())
     }
 
     /// Request a measurement from the SEV firmware.
-    pub fn measure(self) -> Result<Launcher<'a, Measured, U, V>> {
+    pub fn measure(mut self) -> Result<Launcher<Measured>> {
         let mut measurement = MaybeUninit::uninit();
         let mut launch_measure = LaunchMeasure::new(&mut measurement);
-        let mut cmd = Command::from_mut(self.sev, &mut launch_measure);
+        let mut cmd = Command::from_mut(&mut self.sev, &mut launch_measure);
         LAUNCH_MEASUREMENT
-            .ioctl(self.vm_fd, &mut cmd)
+            .ioctl(&mut self.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
 
         let next = Launcher {
@@ -108,7 +108,7 @@ impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Started, U, V> {
     }
 }
 
-impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Measured, U, V> {
+impl Launcher<Measured> {
     /// Get the measurement that the SEV platform recorded.
     pub fn measurement(&self) -> Measurement {
         self.state.1
@@ -121,18 +121,18 @@ impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Measured, U, V> {
     /// This should only be called after a successful attestation flow.
     pub fn inject(&mut self, secret: &Secret, guest: usize) -> Result<()> {
         let launch_secret = LaunchSecret::new(&secret.header, guest, &secret.ciphertext[..]);
-        let mut cmd = Command::from(self.sev, &launch_secret);
+        let mut cmd = Command::from(&mut self.sev, &launch_secret);
         LAUNCH_SECRET
-            .ioctl(self.vm_fd, &mut cmd)
+            .ioctl(&mut self.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
         Ok(())
     }
 
     /// Complete the SEV launch process.
-    pub fn finish(self) -> Result<Handle> {
-        let mut cmd = Command::from(self.sev, &LaunchFinish);
+    pub fn finish(mut self) -> Result<Handle> {
+        let mut cmd = Command::from(&mut self.sev, &LaunchFinish);
         LAUNCH_FINISH
-            .ioctl(self.vm_fd, &mut cmd)
+            .ioctl(&mut self.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
         Ok(self.state.0)
     }

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -13,6 +13,7 @@ use mmarinus::{perms, Map};
 use serial_test::serial;
 
 use std::convert::TryFrom;
+use std::os::unix::io::AsRawFd;
 
 // has to be a multiple of 16
 const CODE: &[u8; 16] = &[
@@ -60,7 +61,7 @@ fn sev() {
     session.update_data(address_space.as_ref()).unwrap();
 
     let (mut launcher, measurement) = {
-        let launcher = Launcher::new(&mut vm, &mut sev).unwrap();
+        let launcher = Launcher::new(vm.as_raw_fd(), sev.as_raw_fd()).unwrap();
         let mut launcher = launcher.start(start).unwrap();
         launcher.update_data(address_space.as_ref()).unwrap();
         let launcher = launcher.measure().unwrap();

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -36,7 +36,7 @@ fn sev() {
     let start = session.start(chain).unwrap();
 
     let kvm = Kvm::new().unwrap();
-    let mut vm = kvm.create_vm().unwrap();
+    let vm = kvm.create_vm().unwrap();
 
     const MEM_SIZE: usize = 0x1000;
     let address_space = Map::bytes(MEM_SIZE)

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::os::unix::io::AsRawFd;
+
 use sev::firmware::Firmware;
 use sev::launch::snp::*;
 
@@ -42,7 +44,7 @@ fn snp() {
     }
 
     let sev = Firmware::open().unwrap();
-    let launcher = Launcher::new(vm_fd, sev).unwrap();
+    let launcher = Launcher::new(vm_fd, sev.as_raw_fd()).unwrap();
 
     let start = Start::new(
         None,

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -44,7 +44,7 @@ fn snp() {
     }
 
     let sev = Firmware::open().unwrap();
-    let launcher = Launcher::new(vm_fd, sev.as_raw_fd()).unwrap();
+    let launcher = Launcher::new(vm_fd.as_raw_fd(), sev.as_raw_fd()).unwrap();
 
     let start = Start::new(
         None,
@@ -73,7 +73,7 @@ fn snp() {
 
     let finish = Finish::new(None, None, [0u8; 32]);
 
-    let vcpu_fd = launcher.as_mut().create_vcpu(0).unwrap();
+    let vcpu_fd = vm_fd.create_vcpu(0).unwrap();
 
     let mut regs = vcpu_fd.get_regs().unwrap();
     regs.rip = MEM_ADDR;


### PR DESCRIPTION
This PR eases the `AsRawFd` trait requirements to the `sev::Launcher` and `snp::Launcher`. Rather than enforce these traits, we can just have callers pass two `RawFd`s (for the VM's file descriptor and `/dev/sev`'s file descriptor) and avoid all the extra boilerplate that comes along with ensuring these traits are satisfied.

I still want to fix another issue upcoming, which is the enforcement of a lifetime on the `launch::Start` struct.