### PR TITLE
launch/sev: Remove lifetime requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ bitfield = "0.14"
 dirs = "4.0"
 iocuddle = "0.1"
 serde-big-array = "0.4.1"
+kvm-ioctls = "0.11"
 
 [dev-dependencies]
 dirs = "4.0"
 kvm-bindings = "0.5"
-kvm-ioctls = "0.11"
 mmarinus = "0.4"
 serial_test = "0.8"

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -60,7 +60,7 @@ fn sev() {
     session.update_data(address_space.as_ref()).unwrap();
 
     let (mut launcher, measurement) = {
-        let launcher = Launcher::new(&mut vm, &mut sev).unwrap();
+        let launcher = Launcher::new(vm.as_raw_fd(), sev.as_raw_fd()).unwrap();
         let mut launcher = launcher.start(start).unwrap();
         launcher.update_data(address_space.as_ref()).unwrap();
         let launcher = launcher.measure().unwrap();

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -2,6 +2,9 @@
 
 #![cfg(feature = "openssl")]
 
+use std::convert::TryFrom;
+use std::os::unix::io::AsRawFd;
+
 use sev::cached_chain;
 use sev::firmware::Firmware;
 use sev::launch::sev::*;
@@ -11,8 +14,6 @@ use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::{Kvm, VcpuExit};
 use mmarinus::{perms, Map};
 use serial_test::serial;
-
-use std::convert::TryFrom;
 
 // has to be a multiple of 16
 const CODE: &[u8; 16] = &[


### PR DESCRIPTION
Instead of a `sev::Launcher` taking references to `AsRawFd` implementers, allow then to take ownership if they see fit. If a caller does not want a `sev::Launcher` to take ownership, they can use `as_raw_fd()`.