### PR TITLE
README: Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ of the `sev` crate. Binaries that result from consumers of this crate are
 expected to run as a process with the necessary privileges to interact
 with the device nodes.
 
-[`firmware`]: ./firmware/index.html
-[`launch`]: ./launch/index.html
+[`firmware`]: ./src/firmware/
+[`launch`]: ./src/launch/
 
 License: Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //! expected to run as a process with the necessary privileges to interact
 //! with the device nodes.
 //!
-//! [`firmware`]: ./firmware/index.html
-//! [`launch`]: ./launch/index.html
+//! [`firmware`]: ./src/firmware/
+//! [`launch`]: ./src/launch/
 
 #![deny(clippy::all)]
 #![deny(missing_docs)]


### PR DESCRIPTION
The links are missing an `src` prefix.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>