### PR TITLE
snp: Adding extended report features

### DIFF
--- a/src/firmware/linux/host/ioctl.rs
+++ b/src/firmware/linux/host/ioctl.rs
@@ -14,16 +14,16 @@ use std::marker::PhantomData;
 // source code: include/uapi/linux/psp-sev.h
 impl_const_id! {
     pub Id => u32;
-    PlatformReset = 0,
-    PlatformStatus = 1,
-    PekGen = 2,
-    PekCsr<'_> = 3,
-    PdhGen = 4,
-    PdhCertExport<'_> = 5,
-    PekCertImport<'_> = 6,
-    GetId<'_> = 8, /* GET_ID2 is 8, the deprecated GET_ID ioctl is 7 */
+    PlatformReset = 0x0,
+    PlatformStatus = 0x1,
+    PekGen = 0x2,
+    PekCsr<'_> = 0x3,
+    PdhGen = 0x4,
+    PdhCertExport<'_> = 0x5,
+    PekCertImport<'_> = 0x6,
+    GetId<'_> = 0x8, /* GET_ID2 is 0x8, the deprecated GET_ID ioctl is 0x7 */
 
-    SnpPlatformStatus = 9,
+    SnpPlatformStatus = 0x9,
     SnpSetExtConfig = 0xA,
     SnpGetExtConfig = 0xB,
 }

--- a/src/firmware/linux/host/ioctl.rs
+++ b/src/firmware/linux/host/ioctl.rs
@@ -24,6 +24,8 @@ impl_const_id! {
     GetId<'_> = 8, /* GET_ID2 is 8, the deprecated GET_ID ioctl is 7 */
 
     SnpPlatformStatus = 9,
+    SnpSetExtConfig = 0xA,
+    SnpGetExtConfig = 0xB,
 }
 
 const SEV: Group = Group::new(b'S');
@@ -57,6 +59,14 @@ pub const GET_ID: Ioctl<WriteRead, &Command<GetId<'_>>> = unsafe { SEV.write_rea
 
 /// Return information about the current status and capabilities of the SEV-SNP platform.
 pub const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<SnpPlatformStatus>> =
+    unsafe { SEV.write_read(0) };
+
+/// Set the SNP Extended Configuration Settings.
+pub const SNP_SET_EXT_CONFIG: Ioctl<WriteRead, &Command<SnpSetExtConfig>> =
+    unsafe { SEV.write_read(0) };
+
+/// Get the SNP Extended Configuration Settings.
+pub const SNP_GET_EXT_CONFIG: Ioctl<WriteRead, &Command<SnpGetExtConfig>> =
     unsafe { SEV.write_read(0) };
 
 /// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is

--- a/src/firmware/linux/host/types.rs
+++ b/src/firmware/linux/host/types.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use codicon::Read;
+
 use crate::certs::sev;
+use crate::firmware::uapi::host::types::{
+    CertTable as UapiCertTable, CertTableEntry as UapiCertTableEntry, SnpExtConfig,
+};
 use crate::Version;
 
 use std::marker::PhantomData;
@@ -247,6 +252,225 @@ impl SnpConfig {
             reported_tcb,
             mask_chip_id,
             reserved: [0; 52],
+        }
+    }
+}
+
+/// Structure used for interacting with the Linux Kernel.
+///
+/// The original C structure looks like this:
+///
+/// ```C
+/// struct cert_table {
+///    struct {
+///       unsigned char guid[16];
+///       uint32 offset;
+///       uint32 length;
+///    } cert_table_entry[];
+/// };
+/// ```
+///
+#[derive(Clone, Default)]
+#[repr(C)]
+pub struct CertTableEntry {
+    /// Sixteen character GUID.
+    guid: [u8; 16],
+
+    /// The starting location of the certificate blob.
+    offset: u32,
+
+    /// The number of bytes to read from the offset.
+    length: u32,
+}
+
+#[repr(C)]
+pub struct CertTable {
+    /// Pointer to the Certificates in question.
+    entries: *const CertTableEntry,
+}
+
+impl Default for CertTable {
+    fn default() -> Self {
+        Self {
+            entries: &CertTableEntry::default() as *const CertTableEntry,
+        }
+    }
+}
+
+impl CertTable {
+    pub fn from_uapi(table: UapiCertTable) -> Self {
+        let mut entries: Vec<CertTableEntry> = vec![];
+        let mut tmp_guid: [u8; 16] = [0u8; 16];
+
+        for entry in table.entries {
+            // We have a problem if the GUID is anything other than 16 bytes.
+            assert_eq!(entry.guid().len(), 16);
+
+            // Copy the GUID into a byte array. Note: Unwrapping should be safe
+            // here, as the value should be present.
+            entry
+                .guid()
+                .as_bytes()
+                .bytes()
+                .zip(tmp_guid.iter_mut())
+                .for_each(|(byte, ptr)| *ptr = byte.unwrap());
+
+            // Push the entry onto the vector.
+            entries.push(CertTableEntry {
+                guid: tmp_guid,
+                offset: entry.data().as_ptr() as *const u8 as u32,
+                length: entry.data().len() as u32,
+            });
+
+            // Zero the tmp array.
+            tmp_guid = [0; 16];
+        }
+
+        CertTable {
+            entries: entries.as_ptr(),
+        }
+    }
+
+    /// Parses the raw array of bytes into more human understandable information.
+    ///
+    /// The original C structure looks like this:
+    ///
+    /// ```C
+    /// struct cert_table {
+    ///    struct {
+    ///       unsigned char guid[16];
+    ///       uint32 offset;
+    ///       uint32 length;
+    ///    } cert_table_entry[];
+    /// };
+    /// ```
+    ///
+    unsafe fn parse_table(&self) -> Vec<UapiCertTableEntry> {
+        const OFFSET_START: isize = (std::mem::size_of::<u8>() * 16) as isize;
+        const LENGTH_START: isize = (std::mem::size_of::<u8>() * 20) as isize;
+        const ENTRY_SIZE: isize = (std::mem::size_of::<u8>() * 24) as isize;
+        const GUID_SIZE: usize = 16_usize;
+
+        let mut retval: Vec<UapiCertTableEntry> = vec![];
+        let mut guid_ptr: *const CertTableEntry = self.entries;
+        let mut guid: String;
+        let mut cert_address: *mut u8;
+        let mut cert_len: usize;
+        let mut cert_end: *mut u8;
+
+        loop {
+            let mut cert_bytes: Vec<u8> = vec![];
+
+            // Calculate values for each CertTableEntry.
+            cert_address = guid_ptr.offset(OFFSET_START) as *mut u8;
+            cert_len = *(guid_ptr.offset(LENGTH_START) as *const usize);
+            cert_end = cert_address.add(cert_len);
+            guid = String::from_raw_parts(guid_ptr as *mut u8, GUID_SIZE, GUID_SIZE);
+
+            // Gather the certificate bytes.
+            while cert_address.ne(&cert_end) {
+                cert_bytes.push(*cert_address);
+                cert_address = cert_address.add(1);
+            }
+
+            // Append the entry to the vector.
+            retval.push(UapiCertTableEntry::from_guid(&guid, cert_bytes));
+
+            // Move the pointer ahead to the next value.
+            guid_ptr = guid_ptr.offset(ENTRY_SIZE);
+
+            // Check for the end of the table.
+            if guid_ptr.eq(&std::ptr::null()) {
+                break;
+            }
+        }
+
+        retval
+    }
+
+    pub fn to_uapi(&self) -> UapiCertTable {
+        UapiCertTable {
+            entries: unsafe { self.parse_table() },
+        }
+    }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct SnpSetExtConfig {
+    /// Address of the SnpConfig or 0 when reported_tcb does not need
+    /// to be updated.
+    pub config_address: u64,
+
+    /// Address of extended guest request [`CertTable`] or 0 when
+    /// previous certificate should be removed on SNP_SET_EXT_CONFIG.
+    pub certs_address: u64,
+
+    /// Length of the certificates.
+    pub certs_len: u32,
+}
+
+impl SnpSetExtConfig {
+    pub(crate) fn from_uapi(data: &SnpExtConfig) -> Self {
+        Self {
+            certs_address: if data.certs.is_none() {
+                0
+            } else {
+                &CertTable::from_uapi(data.certs.clone().unwrap()) as *const CertTable as u64
+            },
+            config_address: if data.config.is_none() {
+                0
+            } else {
+                &data.config.unwrap() as *const SnpConfig as u64
+            },
+            certs_len: if data.certs.is_none() {
+                0
+            } else {
+                data.certs_len
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct SnpGetExtConfig {
+    /// Address of the SnpConfig or 0 when reported_tcb should not be
+    /// fetched.
+    pub config_address: u64,
+
+    /// Address of extended guest request [`CertTable`] or 0 when
+    /// certificate should not be fetched.
+    pub certs_address: u64,
+
+    /// Length of the buffer which will hold the fetched certificates.
+    pub certs_len: u32,
+}
+
+impl SnpGetExtConfig {
+    pub(crate) fn as_uapi(&mut self) -> SnpExtConfig {
+        SnpExtConfig {
+            config: if self.config_address == 0 {
+                None
+            } else {
+                let mut config: SnpConfig = Default::default();
+                let ptr: *mut SnpConfig = &mut config;
+                unsafe {
+                    std::ptr::copy(self.config_address as *const SnpConfig, ptr, 1);
+                    Some(*ptr)
+                }
+            },
+            certs: if self.certs_address == 0 {
+                None
+            } else {
+                let mut chain: CertTable = Default::default();
+                let ptr: *mut CertTable = &mut chain;
+                unsafe {
+                    std::ptr::copy(self.certs_address as *const CertTable, ptr, 1);
+                    Some((*ptr).to_uapi())
+                }
+            },
+            certs_len: self.certs_len,
         }
     }
 }

--- a/src/firmware/uapi/host/mod.rs
+++ b/src/firmware/uapi/host/mod.rs
@@ -157,11 +157,10 @@ impl Firmware {
     }
 
     /// Set the SNP Extended Configuration.
-    pub fn snp_set_ext_config(
-        &mut self,
-        new_config: &SnpExtConfig,
-    ) -> Result<(), Indeterminate<Error>> {
-        let mut config: SnpSetExtConfig = SnpSetExtConfig::from_uapi(new_config);
+    pub fn snp_set_ext_config(&mut self, new_config: &SnpExtConfig) -> Result<(), UserApiError> {
+        let mut config: SnpSetExtConfig = SnpSetExtConfig::from_uapi(new_config)?;
+
+        // Need to translate this from IOError to UserApiError
         SNP_SET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut config))?;
         Ok(())
     }

--- a/src/firmware/uapi/host/mod.rs
+++ b/src/firmware/uapi/host/mod.rs
@@ -148,6 +148,23 @@ impl Firmware {
             },
         })
     }
+
+    /// Fetch the SNP Extended Configuration.
+    pub fn snp_get_ext_config(&mut self) -> Result<SnpExtConfig, Indeterminate<Error>> {
+        let mut config: SnpGetExtConfig = Default::default();
+        SNP_GET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut config))?;
+        Ok(config.as_uapi())
+    }
+
+    /// Set the SNP Extended Configuration.
+    pub fn snp_set_ext_config(
+        &mut self,
+        new_config: &SnpExtConfig,
+    ) -> Result<(), Indeterminate<Error>> {
+        let mut config: SnpSetExtConfig = SnpSetExtConfig::from_uapi(new_config);
+        SNP_SET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut config))?;
+        Ok(())
+    }
 }
 
 impl AsRawFd for Firmware {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sev::cached_chain;
+use sev::firmware::uapi::host::types::{
+    CertTable, CertTableEntry, SnpCertType, SnpConfig, SnpExtConfig, TcbVersion,
+};
 use sev::{certs::sev::Usage, firmware::uapi::host::Firmware, Build, Version};
 
 use serial_test::serial;
@@ -154,4 +157,74 @@ fn snp_platform_status() {
         status.tcb.reported_version.bootloader,
         status.state
     );
+}
+
+fn build_ext_config(cert: bool, cfg: bool) -> SnpExtConfig {
+    let test_cfg: SnpConfig = SnpConfig::new(TcbVersion::new(2, 0, 6, 39), 31);
+    let cert_table: CertTable = CertTable {
+        entries: vec![
+            CertTableEntry::new(SnpCertType::ARK, vec![1; 28]),
+            CertTableEntry::new(SnpCertType::ASK, vec![1; 28]),
+        ],
+    };
+    SnpExtConfig {
+        config: match cfg {
+            true => Some(test_cfg),
+            false => None,
+        },
+        certs: match cert {
+            true => Some(cert_table),
+            false => None,
+        },
+        certs_len: match cert {
+            true => 2,
+            false => 0,
+        },
+    }
+}
+
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
+#[test]
+#[serial]
+fn snp_set_ext_config_std() {
+    let mut fw: Firmware = Firmware::open().unwrap();
+    let new_config: SnpExtConfig = build_ext_config(true, true);
+    fw.snp_set_ext_config(&new_config).unwrap();
+}
+
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
+#[test]
+#[serial]
+fn snp_get_ext_config_std() {
+    let mut fw: Firmware = Firmware::open().unwrap();
+    let new_config: SnpExtConfig = build_ext_config(true, true);
+    fw.snp_set_ext_config(&new_config).unwrap();
+    let hw_config: SnpExtConfig = fw.snp_get_ext_config().unwrap();
+    assert_eq!(new_config, hw_config);
+}
+
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
+#[test]
+#[serial]
+fn snp_get_ext_config_cert_only() {
+    let mut fw: Firmware = Firmware::open().unwrap();
+    let new_config: SnpExtConfig = build_ext_config(true, false);
+    fw.snp_set_ext_config(&new_config).unwrap();
+    let hw_config: SnpExtConfig = fw.snp_get_ext_config().unwrap();
+    assert_eq!(new_config, hw_config);
+}
+
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
+#[test]
+#[serial]
+fn snp_get_ext_config_cfg_only() {
+    let mut fw: Firmware = Firmware::open().unwrap();
+    let new_config: SnpExtConfig = build_ext_config(false, true);
+    fw.snp_set_ext_config(&new_config).unwrap();
+    let hw_config: SnpExtConfig = fw.snp_get_ext_config().unwrap();
+    assert_eq!(new_config, hw_config);
 }


### PR DESCRIPTION
- Added in FFI wrappers for Snp Extended Report Features.
- Added in user apis for interacting with the FFI.
- Added in some unit tests and system tests for validating behavior.

Signed-off-by: Larry Dewey <larry.dewey@amd.com>