### PR TITLE
CI: Reducing CI Targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.51.0
         profile:
           - name: debug
           - name: release


### PR DESCRIPTION
- Removed build specific targer for 1.51.0, as it is unclear why it was specified in the CI yaml.

Addresses #34 

Signed-off-by: Larry Dewey <larry.dewey@amd.com>