### PR TITLE
Revive PlatformStatusFlags export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ static_assert_macro = "^1.1"
 bitfield = "^0.14"
 
 [dev-dependencies]
-kvm-bindings = "0.5"
+kvm-bindings = ">=0.5"
 mmarinus = "0.4"
 serial_test = "0.8"

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -15,6 +15,8 @@ use types::*;
 
 use super::linux::host::{ioctl::*, types::*};
 
+pub use super::linux::host::types::PlatformStatusFlags;
+
 /// A handle to the SEV platform.
 pub struct Firmware(File);
 


### PR DESCRIPTION
97f02e02ea dropped this from the public API, but `sevctl show flags` still needs it