### PR TITLE
firmware/guest: Simplify snp_get_ext_report()

### DIFF
--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -90,15 +90,7 @@ impl Firmware {
 
         SNP_GET_EXT_REPORT.ioctl(
             &mut self.0,
-            &mut SnpGuestRequest::new(
-                message_version,
-                &SnpExtReportReq {
-                    data: ext_report_request.data,
-                    certs_address: ext_report_request.certs_address,
-                    certs_len: ext_report_request.certs_len,
-                },
-                &ext_report_response,
-            ),
+            &mut SnpGuestRequest::new(message_version, &ext_report_request, &ext_report_response),
         )?;
 
         Ok(ext_report_response)


### PR DESCRIPTION
The fix in #30 allows us to use the passed `ext_report_request` argument as-is.

No functional change intended.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>