### PR TITLE
Update Extended Report APIs

### DIFF
--- a/src/certs/sev/cert/v1/sig/ecdsa.rs
+++ b/src/certs/sev/cert/v1/sig/ecdsa.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
 #[cfg(feature = "openssl")]
 use {super::*, openssl::ecdsa};
 
 /// An ECDSA Signature.
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Signature {
+    #[serde(with = "BigArray")]
     r: [u8; 72],
+    #[serde(with = "BigArray")]
     s: [u8; 72],
 }
 

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -90,15 +90,7 @@ impl Firmware {
 
         SNP_GET_EXT_REPORT.ioctl(
             &mut self.0,
-            &mut SnpGuestRequest::new(
-                message_version,
-                &SnpExtReportReq {
-                    data: ext_report_request.data,
-                    certs_address: ext_report_request.certs_address,
-                    certs_len: ext_report_request.certs_len,
-                },
-                &ext_report_response,
-            ),
+            &mut SnpGuestRequest::new(message_version, &ext_report_request, &ext_report_response),
         )?;
 
         Ok(ext_report_response)

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -80,13 +80,15 @@ impl Firmware {
     /// # Arguments
     ///
     /// * `message_version` - (Optional) Used for the SnpGuestRequest, specifies the message version number defaults to 1.
-    /// * `ext_report_request` - an SnpExtReportReq object with its associated data for requesting the extended attestation report.
+    /// * `report_request` - an SnpReportReq object with its associated data.
     ///
     pub fn snp_get_ext_report(
         &mut self,
         message_version: Option<u8>,
-        ext_report_request: SnpExtReportReq,
+        report_request: SnpReportReq,
     ) -> Result<(AttestationReport, CertTable), Indeterminate<Error>> {
+        let ext_report_request: SnpExtReportReq = SnpExtReportReq::new(report_request);
+
         let ext_report_response: SnpReportRsp = SnpReportRsp::default();
         let mut cert_table: CertTable = Default::default();
 

--- a/src/firmware/host/types.rs
+++ b/src/firmware/host/types.rs
@@ -464,7 +464,7 @@ impl CertTableEntry {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 /// Certificates to send to the PSP.
 pub struct CertTable {
     /// A vector of [`CertTableEntry`].

--- a/src/firmware/host/types.rs
+++ b/src/firmware/host/types.rs
@@ -12,6 +12,8 @@ pub use super::Firmware;
 pub use crate::firmware::linux::host::types::{SnpConfig, TcbVersion};
 use types::PlatformStatusFlags;
 
+use serde::{Deserialize, Serialize};
+
 /// There are a number of error conditions that can occur between this
 /// layer all the way down to the SEV platform. Most of these cases have
 /// been enumerated; however, there is a possibility that some error
@@ -389,7 +391,7 @@ pub struct SnpStatus {
     pub tcb: SnpTcbStatus,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// Certificates which are accepted for [`CertTableEntry`]
 pub enum SnpCertType {
     /// AMD Root Signing Key (ARK) certificate
@@ -429,7 +431,7 @@ impl SnpCertType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// An entry with information regarding a specific certificate.
 pub struct CertTableEntry {
     /// A Specificy certificate type.
@@ -464,7 +466,7 @@ impl CertTableEntry {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// Certificates to send to the PSP.
 pub struct CertTable {
     /// A vector of [`CertTableEntry`].

--- a/src/firmware/linux/host/types.rs
+++ b/src/firmware/linux/host/types.rs
@@ -330,6 +330,13 @@ impl CertTable {
             tmp_guid = [0; 16];
         }
 
+        // Make sure we push the empty entry to signfiy the table is finished.
+        entries.push(CertTableEntry {
+            guid: tmp_guid,
+            offset: 0u32,
+            length: 0u32,
+        });
+
         Ok(CertTable {
             entries: entries.as_ptr(),
         })


### PR DESCRIPTION
This is a set of commits to update the extended report API to return the contents of the report and the certificates in a rust-friendly way. It also adds derived serialization and de-serialization to the associated data types to allow easier marshaling between services.

Addresses #43 

Signed-off-by: Larry Dewey <larry.dewey@amd.com>