### PR TITLE
Update and relax kvm-ioctls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ codicon = "3.0"
 dirs = "4.0"
 iocuddle = "0.1"
 serde-big-array = "0.4.1"
-kvm-ioctls = "0.11"
+kvm-ioctls = ">=0.12"
 static_assertions = "^1.1.0"
 bitfield = "^0.13"
 
 [dev-dependencies]
-kvm-bindings = ">=0.5"
+kvm-bindings = ">=0.6"
 mmarinus = "0.4"
 serial_test = "0.8"


### PR DESCRIPTION
Update kvm-ioctls (and kvm-bindings) dependency to the latest available version (0.12.0) and relax the dependency in a optimistic way accepting any future version (this simplifies distro packaging).

Signed-off-by: Sergio Lopez <slp@redhat.com>