### PR TITLE
Fix API breakage of PlatformStatusFlags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Nathaniel McCallum <npmccallum@redhat.com>", "The VirTee Project Developers"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -16,6 +16,8 @@ use types::*;
 use super::linux::guest::types::_4K_PAGE;
 use super::linux::host::{ioctl::*, types::CertTableEntry as FFICertTableEntry, types::*};
 
+pub use super::linux::host::types::PlatformStatusFlags;
+
 /// A handle to the SEV platform.
 pub struct Firmware(File);
 


### PR DESCRIPTION
- Fixes #57 
- Reinstate the public export of PlatformStatusFlags
- Upgrade crate version for dependents to target