### PR TITLE
rustfmt: Add configuration file .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+newline_style = "Unix"


### PR DESCRIPTION
Add .rustfmt.toml configuration file that sets checking options for rustfmt and cargo fmt. Start basic configuration that enforces edition from 2021 and Unix style, which is the case for prior code history.

Signed-off-by: Carlos Bilbao <carlos.bilbao@amd.com>