### PR TITLE
firmware/guest: Make FFICertTableEntry::parse_table() public

### DIFF
--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -5,12 +5,13 @@
 /// Rust-friendly types returned by FFI wrapping APIs.
 pub mod types;
 
+pub use super::linux::host::types::CertTableEntry as FFICertTableEntry;
+
 use std::fs::{File, OpenOptions};
 
 use self::types::*;
 
 use super::host::types::{CertTableEntry, Error, Indeterminate, UserApiError};
-use super::linux::host::types::CertTableEntry as FFICertTableEntry;
 use crate::firmware::linux::guest::ioctl::*;
 
 /// A handle to the SEV, SEV-ES, or SEV-SNP platform.

--- a/src/firmware/linux/host/types.rs
+++ b/src/firmware/linux/host/types.rs
@@ -366,6 +366,11 @@ impl CertTableEntry {
     /// };
     /// ```
     ///
+    /// # Safety
+    ///
+    /// Since this function manually parses the bytes of the table and utilizes pointers, it
+    /// violates the Rust memory safety guarentee.
+    ///
     pub unsafe fn parse_table(
         mut data: *mut CertTableEntry,
     ) -> Result<Vec<UapiCertTableEntry>, uuid::Error> {


### PR DESCRIPTION
I don't care much for `FFICertTableEntry` being publicly available to users, as it should never be used. However, the `parse_table()` method associated with the struct is quite useful for deserializing bytes into a cert table.

Maybe we should separate this function from `FFICertTableEntry` and only make `parse_table()` public?