### PR TITLE
guest: Remove '&mut' from some public APIs

### DIFF
--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -37,13 +37,13 @@ impl Firmware {
     pub fn snp_get_report(
         &mut self,
         message_version: Option<u8>,
-        report_request: &mut SnpReportReq,
+        mut report_request: SnpReportReq,
     ) -> Result<AttestationReport, Indeterminate<Error>> {
         let mut report_response: SnpReportRsp = SnpReportRsp::default();
 
         SNP_GET_REPORT.ioctl(
             &mut self.0,
-            &mut SnpGuestRequest::new(message_version, report_request, &mut report_response),
+            &mut SnpGuestRequest::new(message_version, &mut report_request, &mut report_response),
         )?;
 
         Ok(report_response.report)
@@ -59,7 +59,7 @@ impl Firmware {
     pub fn snp_get_derived_key(
         &mut self,
         message_version: Option<u8>,
-        derived_key_request: &mut SnpDerivedKey,
+        derived_key_request: SnpDerivedKey,
     ) -> Result<SnpDerivedKeyRsp, Indeterminate<Error>> {
         let mut derived_key_response: SnpDerivedKeyRsp = SnpDerivedKeyRsp::default();
 
@@ -67,7 +67,7 @@ impl Firmware {
             &mut self.0,
             &mut SnpGuestRequest::new(
                 message_version,
-                &mut SnpDerivedKeyReq::from_uapi(*derived_key_request),
+                &mut SnpDerivedKeyReq::from_uapi(derived_key_request),
                 &mut derived_key_response,
             ),
         )?;
@@ -85,7 +85,7 @@ impl Firmware {
     pub fn snp_get_ext_report(
         &mut self,
         message_version: Option<u8>,
-        report_request: &mut SnpReportReq,
+        report_request: SnpReportReq,
     ) -> Result<(AttestationReport, Vec<CertTableEntry>), UserApiError> {
         // Define a buffer to store the certificates in.
         let mut certificate_bytes: Vec<u8>;
@@ -93,7 +93,7 @@ impl Firmware {
         // Due to the complex buffer allocation, we will take the SnpReportReq
         // provided by the caller, and create an extended report request object
         // for them.
-        let mut ext_report_request: SnpExtReportReq = SnpExtReportReq::new(report_request);
+        let mut ext_report_request: SnpExtReportReq = SnpExtReportReq::new(&report_request);
 
         // Create an object for the PSP to store the response content in.
         let mut ext_report_response: SnpReportRsp = Default::default();

--- a/src/firmware/linux/guest/types.rs
+++ b/src/firmware/linux/guest/types.rs
@@ -91,7 +91,7 @@ pub struct SnpExtReportReq {
 impl SnpExtReportReq {
     /// Creates a new exteded report with a one, 4K-page
     /// for the certs_address field and the certs_len field.
-    pub fn new(data: &mut SnpReportReq) -> Self {
+    pub fn new(data: &SnpReportReq) -> Self {
         Self {
             data: *data,
             certs_address: u64::MAX,


### PR DESCRIPTION
Between v1.0 and v1.1, the public API changed to match the underlying ioctl API, which could potentially modify request objects. This is not necessary for the following functions, because:

- snp_get_report: the kernel does not write into the request object (and there are no fields for which it would make sense)
- snp_get_ext_report: the request object is copied into the extended request object expected by the ioctl. The kernel returns the certificate length in the request object but we hide this from the caller.
- snp_get_derived_key: the passed request object is copied before passing to the ioctl.