### PR TITLE
snp_reset: Fixing the snp_reset API

### DIFF
--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -194,8 +194,10 @@ impl Firmware {
     /// ```
     #[cfg(feature = "snp")]
     pub fn snp_reset_config(&mut self) -> Result<(), UserApiError> {
+        let config: Config = Config::new(TcbVersion::default(), 0);
+
         let mut config: FFI::types::SnpSetExtConfig = FFI::types::SnpSetExtConfig {
-            config_address: 0,
+            config_address: &config as *const Config as u64,
             certs_address: 0,
             certs_len: 0,
         };


### PR DESCRIPTION
According to the specification, in order to reset the `REPORTED_TCB`, it is required that `snp_set_ext_config` receive a configuration with a TcbVersion of 0. Previously I was just sending a configuration address of zero, which does nothing.