### PR TITLE
Declare minimal Rust version in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["amd", "sev"]
 categories = ["os", "os::linux-apis", "parsing", "network-programming", "hardware-support"]
 exclude = [ ".gitignore", ".github/*" ]
+rust-verson = "1.66.1"
 
 [badges]
 # See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section


### PR DESCRIPTION
This PR proposed to declare minimal Rust version in `Cargo.toml`.
Explicitly declaring the minimal version can help developers.

The version is considered what `cargo msrv` says.

```
$ cargo msrv
...
  Finished The MSRV is: 1.66.1 
```