### PR TITLE
tests: Deprecate mmarinus, use libc's mmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ is-it-maintained-issue-resolution = { repository = "virtee/sev" }
 is-it-maintained-open-issues = { repository = "virtee/sev" }
 
 [features]
-default = [ "sev", "snp" ]
+default = ["sev", "snp"]
 hw_tests = []
 dangerous_hw_tests = ["hw_tests"]
 sev = []
@@ -42,8 +42,8 @@ bitfield = "^0.13"
 uuid = { version = "^1.2", features = [ "serde" ] }
 bincode = "^1.3"
 hex = "0.4.3"
+libc = "0.2.147"
 
 [dev-dependencies]
 kvm-bindings = ">=0.6"
-mmarinus = "0.4"
 serial_test = "2.0"

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -119,7 +119,7 @@ impl Firmware {
         data: Option<[u8; 64]>,
         vmpl: Option<u32>,
     ) -> Result<(AttestationReport, Vec<CertTableEntry>), UserApiError> {
-        let mut report_request = ReportReq::new(data, vmpl)?;
+        let report_request = ReportReq::new(data, vmpl)?;
 
         let mut report_response = ReportRsp::default();
 
@@ -129,7 +129,7 @@ impl Firmware {
         // Due to the complex buffer allocation, we will take the ReportReq
         // provided by the caller, and create an extended report request object
         // for them.
-        let mut ext_report_request = ExtReportReq::new(&mut report_request);
+        let mut ext_report_request = ExtReportReq::new(&report_request);
 
         // Construct the object needed to perform the IOCTL request.
         // *NOTE:* This is __important__ because a fw_err value which matches

--- a/src/firmware/linux/guest/types.rs
+++ b/src/firmware/linux/guest/types.rs
@@ -95,7 +95,7 @@ pub struct ExtReportReq {
 impl ExtReportReq {
     /// Creates a new exteded report with a one, 4K-page
     /// for the certs_address field and the certs_len field.
-    pub fn new(data: &mut ReportReq) -> Self {
+    pub fn new(data: &ReportReq) -> Self {
         Self {
             data: *data,
             certs_address: u64::MAX,

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -104,7 +104,7 @@ impl CertTableEntry {
     ///
     /// ```
     ///
-    pub fn uapi_to_vec_bytes(table: &mut Vec<UAPI::CertTableEntry>) -> Result<Vec<u8>, CertError> {
+    pub fn uapi_to_vec_bytes(table: &Vec<UAPI::CertTableEntry>) -> Result<Vec<u8>, CertError> {
         // Create the vector to return for later.
         let mut bytes: Vec<u8> = vec![];
 

--- a/src/launch/linux/ioctl.rs
+++ b/src/launch/linux/ioctl.rs
@@ -180,7 +180,7 @@ pub struct Command<'a, T: Id> {
 
 impl<'a, T: Id> Command<'a, T> {
     /// create the command from a mutable subcommand
-    pub fn from_mut(sev: &'a mut impl AsRawFd, subcmd: &'a mut T) -> Self {
+    pub fn from_mut(sev: &'a impl AsRawFd, subcmd: &'a mut T) -> Self {
         Self {
             code: T::ID,
             data: subcmd as *mut T as _,
@@ -191,7 +191,7 @@ impl<'a, T: Id> Command<'a, T> {
     }
 
     /// create the command from a subcommand reference
-    pub fn from(sev: &'a mut impl AsRawFd, subcmd: &'a T) -> Self {
+    pub fn from(sev: &'a impl AsRawFd, subcmd: &'a T) -> Self {
         Self {
             code: T::ID,
             data: subcmd as *const T as _,

--- a/src/launch/snp.rs
+++ b/src/launch/snp.rs
@@ -53,7 +53,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
 
         let init = Init::default();
 
-        let mut cmd = Command::from(&mut launcher.sev, &init);
+        let mut cmd = Command::from(&launcher.sev, &init);
         SNP_INIT
             .ioctl(&mut launcher.vm_fd, &mut cmd)
             .map_err(|e| cmd.encapsulate(e))?;
@@ -64,7 +64,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
     /// Initialize the flow to launch a guest.
     pub fn start(mut self, start: Start) -> Result<Launcher<Started, U, V>> {
         let mut launch_start = LaunchStart::from(start);
-        let mut cmd = Command::from_mut(&mut self.sev, &mut launch_start);
+        let mut cmd = Command::from_mut(&self.sev, &mut launch_start);
 
         SNP_LAUNCH_START
             .ioctl(&mut self.vm_fd, &mut cmd)
@@ -84,7 +84,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
     /// Encrypt guest SNP data.
     pub fn update_data(&mut self, update: Update) -> Result<()> {
         let launch_update_data = LaunchUpdate::from(update);
-        let mut cmd = Command::from(&mut self.sev, &launch_update_data);
+        let mut cmd = Command::from(&self.sev, &launch_update_data);
 
         KvmEncRegion::new(update.uaddr).register(&mut self.vm_fd)?;
 
@@ -98,7 +98,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
     /// Complete the SNP launch process.
     pub fn finish(mut self, finish: Finish) -> Result<(U, V)> {
         let launch_finish = LaunchFinish::from(finish);
-        let mut cmd = Command::from(&mut self.sev, &launch_finish);
+        let mut cmd = Command::from(&self.sev, &launch_finish);
 
         SNP_LAUNCH_FINISH
             .ioctl(&mut self.vm_fd, &mut cmd)


### PR DESCRIPTION
We only use `mmarinus` to allocate a 1kB page of memory in our tests. `libc`'s `mmap` can do this for us.