### PR TITLE
Cleanup meaningless code.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features --all-targets -- -D clippy::all -D unused_imports -Dwarnings
 
   readme:
     name: cargo readme

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -326,8 +326,8 @@ mod test {
                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
                 5, 5, 5, 7, 7, 7, 7, 7, 7,
             ];
-            let mut data: Vec<UAPI::CertTableEntry> = build_vec_uapi_cert_table();
-            let actual: Vec<u8> = CertTableEntry::uapi_to_vec_bytes(&mut data).unwrap();
+            let data: Vec<UAPI::CertTableEntry> = build_vec_uapi_cert_table();
+            let actual: Vec<u8> = CertTableEntry::uapi_to_vec_bytes(&data).unwrap();
             assert_eq!(expected, actual);
         }
 

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -95,7 +95,7 @@ fn sev() {
     vcpu.set_sregs(&sregs).unwrap();
 
     let mut regs = vcpu.get_regs().unwrap();
-    regs.rip = std::ptr::null() as *const u64 as u64;
+    regs.rip = std::ptr::null::<u64>() as u64;
     regs.rflags = 2;
     vcpu.set_regs(&regs).unwrap();
 

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -76,7 +76,7 @@ fn snp() {
 
     let update = Update::new(
         mem_region.guest_phys_addr >> 12,
-        address_space.as_ref(),
+        address_space,
         false,
         PageType::Normal,
         (dp, dp, dp),


### PR DESCRIPTION
This PR aims to cleanup meaningless code.
They are detected by `cargo clippy --all-features --all-targets -- -D clippy::all -D unused_imports -Dwarnings`, and I suggest to do clippy with these options in CI.