### PR TITLE
Compile on windows & macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,4 @@ jobs:
           - name: release
             flag: --release
         features:
-          -
           - openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "sev"
 version = "1.2.1"
-authors = ["Nathaniel McCallum <npmccallum@redhat.com>", "The VirTee Project Developers"]
+authors = [
+    "Nathaniel McCallum <npmccallum@redhat.com>",
+    "The VirTee Project Developers",
+]
 license = "Apache-2.0"
 edition = "2018"
 homepage = "https://github.com/virtee/sev"
@@ -9,9 +12,15 @@ repository = "https://github.com/virtee/sev"
 description = "Library for AMD SEV"
 readme = "README.md"
 keywords = ["amd", "sev"]
-categories = ["os", "os::linux-apis", "parsing", "network-programming", "hardware-support"]
-exclude = [ ".gitignore", ".github/*" ]
-rust-verson = "1.66.1"
+categories = [
+    "os",
+    "os::linux-apis",
+    "parsing",
+    "network-programming",
+    "hardware-support",
+]
+exclude = [".gitignore", ".github/*"]
+rust-version = "1.66.1"
 
 [badges]
 # See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
@@ -29,6 +38,9 @@ sev = []
 snp = []
 capi = []
 
+[target.'cfg(target_os = "linux")'.dependencies]
+iocuddle = "0.1"
+
 [dependencies]
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -36,17 +48,16 @@ serde_bytes = "0.11"
 bitflags = "1.2"
 codicon = "3.0"
 dirs = "5.0"
-iocuddle = "0.1"
 serde-big-array = "0.5.1"
-kvm-ioctls = ">=0.12"
 static_assertions = "^1.1.0"
 bitfield = "^0.13"
-uuid = { version = "^1.2", features = [ "serde" ] }
+uuid = { version = "^1.2", features = ["serde"] }
 bincode = "^1.3"
 hex = "0.4.3"
 libc = "0.2.147"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
+kvm-ioctls = ">=0.12"
 kvm-bindings = ">=0.6"
 serial_test = "2.0"

--- a/src/certs/sev/crypto.rs
+++ b/src/certs/sev/crypto.rs
@@ -4,6 +4,7 @@ use super::*;
 
 use std::fmt::{Debug, Formatter};
 
+#[cfg(target_os = "linux")]
 impl<U> PrivateKey<U> {
     pub(crate) fn derive(&self, cert: &sev::Certificate) -> Result<Vec<u8>> {
         let key = PublicKey::try_from(cert)?;

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -10,6 +10,7 @@ mod types;
 
 pub use types::*;
 
+#[cfg(target_os = "linux")]
 use crate::{
     error::*,
     firmware::{
@@ -21,6 +22,7 @@ use crate::{
     },
 };
 
+#[cfg(target_os = "linux")]
 use std::fs::{File, OpenOptions};
 
 // Disabled until upstream Linux kernel is patched.
@@ -47,8 +49,10 @@ use std::fs::{File, OpenOptions};
 // }
 
 /// A handle to the SEV-SNP guest device.
+#[cfg(target_os = "linux")]
 pub struct Firmware(File);
 
+#[cfg(target_os = "linux")]
 impl Firmware {
     /// Generate a new file handle to the SEV guest platform via `/dev/sev-guest`.
     ///

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -5,30 +5,37 @@ mod types;
 
 pub use types::*;
 
+#[cfg(target_os = "linux")]
 use super::linux::host::{ioctl::*, types::GetId};
 
 #[cfg(feature = "sev")]
+#[cfg(target_os = "linux")]
 use super::linux::host::types::{
     PdhCertExport, PdhGen, PekCertImport, PekCsr, PekGen, PlatformReset, PlatformStatus,
 };
 
+#[cfg(target_os = "linux")]
 use crate::error::*;
 
 #[cfg(feature = "sev")]
+#[cfg(target_os = "linux")]
 use crate::{
     certs::sev::sev::{Certificate, Chain},
     Build as CertBuild, Version as CertVersion,
 };
 
+#[cfg(target_os = "linux")]
 use std::{
     fs::{File, OpenOptions},
     os::unix::io::{AsRawFd, RawFd},
 };
 
 #[cfg(feature = "sev")]
+#[cfg(target_os = "linux")]
 use std::mem::MaybeUninit;
 
 #[cfg(feature = "snp")]
+#[cfg(target_os = "linux")]
 use std::convert::TryInto;
 
 /// The CPU-unique identifier for the platform.
@@ -52,8 +59,10 @@ impl std::fmt::Display for Identifier {
 }
 
 /// A handle to the SEV platform.
+#[cfg(target_os = "linux")]
 pub struct Firmware(File);
 
+#[cfg(target_os = "linux")]
 impl Firmware {
     /// Create a handle to the SEV platform.
     pub fn open() -> std::io::Result<Firmware> {
@@ -284,6 +293,7 @@ impl Firmware {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl AsRawFd for Firmware {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()

--- a/src/firmware/linux/guest/mod.rs
+++ b/src/firmware/linux/guest/mod.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(target_os = "linux")]
 pub(crate) mod ioctl;
+#[cfg(target_os = "linux")]
 pub(crate) mod types;

--- a/src/firmware/linux/host/mod.rs
+++ b/src/firmware/linux/host/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Host FFI Wrappers for C Kernel APIs
+#[cfg(target_os = "linux")]
 pub(crate) mod ioctl;
 pub(crate) mod types;

--- a/src/firmware/linux/host/types/mod.rs
+++ b/src/firmware/linux/host/types/mod.rs
@@ -13,10 +13,12 @@ pub use self::sev::*;
 pub use self::snp::*;
 
 #[cfg(any(feature = "sev", feature = "snp"))]
+#[cfg(target_os = "linux")]
 use std::marker::PhantomData;
 
 /// Get the CPU's unique ID that can be used for getting
 /// a certificate for the CEK public key.
+#[cfg(target_os = "linux")]
 #[cfg(any(feature = "sev", feature = "snp"))]
 #[repr(C, packed)]
 pub struct GetId<'a> {
@@ -26,6 +28,7 @@ pub struct GetId<'a> {
 }
 
 #[cfg(any(feature = "sev", feature = "snp"))]
+#[cfg(target_os = "linux")]
 impl<'a> GetId<'a> {
     pub fn new(id: &'a mut [u8; 64]) -> Self {
         Self {
@@ -46,4 +49,5 @@ impl<'a> GetId<'a> {
 ///
 /// (Chapter 5.5)
 #[cfg(feature = "sev")]
+#[cfg(target_os = "linux")]
 pub struct PlatformReset;

--- a/src/firmware/linux/host/types/sev.rs
+++ b/src/firmware/linux/host/types/sev.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{certs::sev::sev, Version};
+#[cfg(target_os = "linux")]
+use crate::certs::sev::sev;
 
+use crate::Version;
+
+#[cfg(target_os = "linux")]
 use std::marker::PhantomData;
 
 bitflags::bitflags! {
@@ -46,18 +50,21 @@ pub struct PlatformStatus {
 /// Generate a new Platform Endorsement Key (PEK).
 ///
 /// (Chapter 5.7)
+#[cfg(target_os = "linux")]
 pub struct PekGen;
 
 /// Request certificate signing.
 ///
 /// (Chapter 5.8; Table 27)
 #[repr(C, packed)]
+#[cfg(target_os = "linux")]
 pub struct PekCsr<'a> {
     addr: u64,
     len: u32,
     _phantom: PhantomData<&'a ()>,
 }
 
+#[cfg(target_os = "linux")]
 impl<'a> PekCsr<'a> {
     pub fn new(cert: &'a mut sev::Certificate) -> Self {
         Self {
@@ -71,6 +78,7 @@ impl<'a> PekCsr<'a> {
 /// Join the platform to the domain.
 ///
 /// (Chapter 5.9; Table 29)
+#[cfg(target_os = "linux")]
 #[repr(C, packed)]
 pub struct PekCertImport<'a> {
     pek_addr: u64,
@@ -80,6 +88,7 @@ pub struct PekCertImport<'a> {
     _phantom: PhantomData<&'a ()>,
 }
 
+#[cfg(target_os = "linux")]
 impl<'a> PekCertImport<'a> {
     pub fn new(pek: &'a sev::Certificate, oca: &'a sev::Certificate) -> Self {
         Self {
@@ -95,11 +104,13 @@ impl<'a> PekCertImport<'a> {
 /// (Re)generate the Platform Diffie-Hellman (PDH).
 ///
 /// (Chapter 5.10)
+#[cfg(target_os = "linux")]
 pub struct PdhGen;
 
 /// Retrieve the PDH and the platform certificate chain.
 ///
 /// (Chapter 5.11)
+#[cfg(target_os = "linux")]
 #[repr(C, packed)]
 pub struct PdhCertExport<'a> {
     pdh_addr: u64,
@@ -109,6 +120,7 @@ pub struct PdhCertExport<'a> {
     _phantom: PhantomData<&'a ()>,
 }
 
+#[cfg(target_os = "linux")]
 impl<'a> PdhCertExport<'a> {
     pub fn new(pdh: &'a mut sev::Certificate, certs: &'a mut [sev::Certificate; 3]) -> Self {
         Self {

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::CertError, firmware::host as UAPI};
+#[cfg(target_os = "linux")]
+use crate::error::CertError;
+
+use crate::firmware::host as UAPI;
 
 use uuid::Uuid;
 
@@ -104,6 +107,7 @@ impl CertTableEntry {
     ///
     /// ```
     ///
+    #[cfg(target_os = "linux")]
     pub fn uapi_to_vec_bytes(table: &Vec<UAPI::CertTableEntry>) -> Result<Vec<u8>, CertError> {
         // Create the vector to return for later.
         let mut bytes: Vec<u8> = vec![];

--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Operations and types for launching on Linux
-
 pub(crate) mod ioctl;
 
 #[cfg(feature = "sev")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,9 @@
 pub mod certs;
 
 pub mod firmware;
+#[cfg(target_os = "linux")]
 pub mod launch;
-#[cfg(all(feature = "openssl", feature = "sev"))]
+#[cfg(all(target_os = "linux", feature = "openssl", feature = "sev"))]
 pub mod session;
 mod util;
 pub mod vmsa;

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -34,8 +34,8 @@ fn sev() {
     let mut sev = Firmware::open().unwrap();
     let build = sev.platform_status().unwrap().build;
     let chain = cached_chain::get().expect(
-        r#"could not find certificate chain
-        export with: sevctl export --full ~/.cache/amd-sev/chain"#,
+        r"could not find certificate chain
+        export with: sevctl export --full ~/.cache/amd-sev/chain",
     );
 
     let policy = Policy::default();
@@ -100,7 +100,7 @@ fn sev() {
     vcpu.set_regs(&regs).unwrap();
 
     match vcpu.run().unwrap() {
-        VcpuExit::Hlt => return,
+        VcpuExit::Hlt => (),
         exit_reason => panic!("unexpected exit reason: {:?}", exit_reason),
     }
 }


### PR DESCRIPTION
Fully support Windows & MacOS compilation. The attestation report can only be generated on Linux whereas the attestation report management such as parsing or verification can be proceeded on Linux, MacOS and Windows.

```sh
$ sudo apt-get install --no-install-recommends -qq libclang-dev gcc-mingw-w64-x86-64
$ rustup target add x86_64-pc-windows-gnu
$ rustup target add x86_64-apple-darwin
$ cargo build  --target  x86_64-pc-windows-gnu --features snp,sev,openssl
$ cargo build  --target  x86_64-apple-darwin --features snp,sev,openssl
```