### PR TITLE
Allow verification of SNP AttestationReport without OpenSSL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: cargo clippy
+  clippy-openssl:
+    name: cargo clippy openssl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,23 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --all-targets -- -D clippy::all -D unused_imports -Dwarnings
+          args: --features=openssl,hw_tests,dangerous_hw_tests --all-targets -- -D clippy::all -D unused_imports -Dwarnings
+
+  clippy-crypto_nossl:
+    name: cargo clippy crypto_nossl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features=crypto_nossl,hw_tests,dangerous_hw_tests --all-targets -- -D clippy::all -D unused_imports -Dwarnings
 
   readme:
     name: cargo readme

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 on: [push, pull_request]
 name: test
 jobs:
-  sw:
-    name: sw ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
+  sw-openssl:
+    name: sw openssl ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,3 +27,30 @@ jobs:
             flag: --release
         features:
           - openssl
+
+  sw-crypto_nossl:
+    name: sw crypto_nossl ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.profile.flag }} --features=${{ matrix.features }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - nightly
+          - beta
+          - stable
+        profile:
+          - name: debug
+          - name: release
+            flag: --release
+        features:
+          - crypto_nossl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ hw_tests = []
 dangerous_hw_tests = ["hw_tests"]
 sev = []
 snp = []
+crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iocuddle = "0.1"
@@ -61,6 +62,10 @@ bincode = "^1.3"
 hex = "0.4.3"
 libc = "0.2.147"
 lazy_static = "1.4.0"
+p384 = { version = "0.13.0", optional = true }
+rsa = { version = "0.9.2", optional = true }
+sha2 = { version = "0.10.8", optional = true }
+x509-cert = { version = "0.2.4", optional = true }
 
 [dev-dependencies]
 kvm-ioctls = ">=0.12"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Refer to the [`firmware`] module for more information.
 
 Refer to the [`launch`] module for more information.
 
+### Cryptographic Verification
+
+To enable the cryptographic verification of certificate chains and
+attestation reports, either the `openssl` or `crypto_nossl` feature
+has to be enabled manually. With `openssl`, OpenSSL is used for the
+verification. With `crypto_nossl`, OpenSSL is _not_ used for the
+verification and instead pure-Rust libraries (e.g., `p384`, `rsa`,
+etc.) are used. `openssl` and `crypto_nossl` are mutually exclusive,
+and enabling both at the same time leads to a compiler error.
+
 ### Remarks
 
 Note that the Linux kernel provides access to these APIs through a set

--- a/src/certs/snp/builtin/genoa/mod.rs
+++ b/src/certs/snp/builtin/genoa/mod.rs
@@ -10,12 +10,12 @@ pub const ASK: &[u8] = include_bytes!("ask.pem");
 
 /// Get the Genoa ARK Certificate.
 pub fn ark() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ARK)?))
+    Certificate::from_pem(ARK)
 }
 
 /// Get the Genoa ASK Certificate.
 pub fn ask() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ASK)?))
+    Certificate::from_pem(ASK)
 }
 
 mod tests {

--- a/src/certs/snp/builtin/milan/mod.rs
+++ b/src/certs/snp/builtin/milan/mod.rs
@@ -10,12 +10,12 @@ pub const ASK: &[u8] = include_bytes!("ask.pem");
 
 /// Get the Milan ARK Certificate.
 pub fn ark() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ARK)?))
+    Certificate::from_pem(ARK)
 }
 
 /// Get the Milan ASK Certificate.
 pub fn ask() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ASK)?))
+    Certificate::from_pem(ASK)
 }
 
 mod tests {

--- a/src/certs/snp/cert.rs
+++ b/src/certs/snp/cert.rs
@@ -3,10 +3,11 @@
 use super::*;
 
 use openssl::pkey::{PKey, Public};
+use openssl::x509::X509;
 
 /// Structures/interfaces for SEV-SNP certificates.
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Certificate(X509);
 
 /// Wrap an X509 struct into a Certificate.

--- a/src/certs/snp/cert_nossl.rs
+++ b/src/certs/snp/cert_nossl.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+use der::{referenced::OwnedToRef, Decode, DecodePem, Encode};
+use rsa::signature; // re-export of signature crate
+use signature::Verifier;
+use spki::ObjectIdentifier;
+use std::convert::TryFrom;
+use std::io;
+use std::io::ErrorKind;
+use x509_cert::der; // re-export of der crate
+use x509_cert::spki; // re-export of spki crate
+
+/// Structures/interfaces for SEV-SNP certificates.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Certificate(x509_cert::Certificate);
+
+const RSA_SSA_PSS_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
+
+/// Verify if the public key of one Certificate signs another Certificate.
+impl Verifiable for (&Certificate, &Certificate) {
+    type Output = ();
+
+    fn verify(self) -> Result<Self::Output> {
+        let signer = &self.0 .0;
+        let signee = &self.1 .0;
+
+        if signee.signature_algorithm.oid != RSA_SSA_PSS_OID {
+            return Err(io_error_other(format!(
+                "unsupported signature algorithm: {:?}",
+                signee.signature_algorithm
+            )));
+        }
+
+        let rsa_verifying_key = {
+            let signer_spki_ref = signer
+                .tbs_certificate
+                .subject_public_key_info
+                .owned_to_ref();
+            let signer_pubkey_rsa = rsa::RsaPublicKey::try_from(signer_spki_ref)
+                .map_err(|e| io_error_other(format!("invalid RSA public key: {e:?}")))?;
+            rsa::pss::VerifyingKey::<sha2::Sha384>::new(signer_pubkey_rsa)
+        };
+
+        let message = signee.tbs_certificate.to_der().map_err(|e| {
+            io_error_other(format!("failed to encode tbs_certificate as DER: {e:?}"))
+        })?;
+
+        let rsa_signature = rsa::pss::Signature::try_from(signee.signature.raw_bytes())
+            .map_err(|e| io_error_other(format!("invalid RSA signature: {e:?}")))?;
+
+        rsa_verifying_key
+            .verify(&message, &rsa_signature)
+            .map_err(|e| {
+                io_error_other(format!(
+                    "Signer certificate does not RSA sign signee certificate: {e}"
+                ))
+            })
+    }
+}
+
+impl Certificate {
+    /// Create a Certificate from a PEM-encoded X509 structure.
+    pub fn from_pem(pem: &[u8]) -> Result<Self> {
+        let cert = x509_cert::Certificate::from_pem(pem)
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, format!("invalid PEM: {}", e)))?;
+        Ok(Self(cert))
+    }
+
+    /// Serialize a Certificate struct to PEM.
+    pub fn to_pem(&self) -> Result<Vec<u8>> {
+        use der::EncodePem;
+        Ok(self
+            .0
+            .to_pem(der::pem::LineEnding::default())
+            .map_err(|e| io_error_other(format!("PEM-encoding failed: {}", e)))?
+            .into_bytes())
+    }
+
+    /// Create a Certificate from a DER-encoded X509 structure.
+    pub fn from_der(der: &[u8]) -> Result<Self> {
+        let cert = x509_cert::Certificate::from_der(der)
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, format!("invalid DER: {}", e)))?;
+        Ok(Self(cert))
+    }
+
+    /// Serialize a Certificate struct to DER.
+    pub fn to_der(&self) -> Result<Vec<u8>> {
+        self.0
+            .to_der()
+            .map_err(|e| io_error_other(format!("DER-encoding failed: {e:?}")))
+    }
+
+    /// Retrieve the public key in SEC1 encoding.
+    pub fn public_key_sec1(&self) -> &[u8] {
+        self.0
+            .tbs_certificate
+            .subject_public_key_info
+            .subject_public_key
+            .raw_bytes()
+    }
+}
+
+fn io_error_other<S: Into<String>>(error: S) -> io::Error {
+    io::Error::new(ErrorKind::Other, error.into())
+}

--- a/src/certs/snp/mod.rs
+++ b/src/certs/snp/mod.rs
@@ -3,39 +3,40 @@
 /// ECDSA signatures.
 pub mod ecdsa;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 /// Certificate Authority (CA) certificates.
 pub mod ca;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 /// Built-in certificates for Milan and Genoa machines.
 pub mod builtin;
 
 #[cfg(feature = "openssl")]
 mod cert;
+#[cfg(feature = "crypto_nossl")]
+mod cert_nossl;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 mod chain;
 
 #[cfg(feature = "openssl")]
 pub use cert::Certificate;
+#[cfg(feature = "crypto_nossl")]
+pub use cert_nossl::Certificate;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 pub use chain::Chain;
 
 use std::io::Result;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 use std::io::{Error, ErrorKind};
-
-#[cfg(feature = "openssl")]
-use openssl::x509::X509;
 
 #[cfg(feature = "openssl")]
 #[allow(dead_code)]
 struct Body;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 /// An interface for types that may contain entities such as
 /// signatures that must be verified.
 pub trait Verifiable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,16 @@
 //!
 //! Refer to the [`launch`] module for more information.
 //!
+//! ## Cryptographic Verification
+//!
+//! To enable the cryptographic verification of certificate chains and
+//! attestation reports, either the `openssl` or `crypto_nossl` feature
+//! has to be enabled manually. With `openssl`, OpenSSL is used for the
+//! verification. With `crypto_nossl`, OpenSSL is _not_ used for the
+//! verification and instead pure-Rust libraries (e.g., `p384`, `rsa`,
+//! etc.) are used. `openssl` and `crypto_nossl` are mutually exclusive,
+//! and enabling both at the same time leads to a compiler error.
+//!
 //! ## Remarks
 //!
 //! Note that the Linux kernel provides access to these APIs through a set
@@ -45,6 +55,11 @@
 #![allow(unknown_lints)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::unreadable_literal)]
+
+#[cfg(all(feature = "openssl", feature = "crypto_nossl"))]
+compile_error!(
+    "feature \"openssl\" and feature \"crypto_nossl\" cannot be enabled at the same time"
+);
 
 /// SEV and SEV-SNP certificates interface.
 pub mod certs;


### PR DESCRIPTION
Allows the verification of an SNP `AttestationReport` without the use of OpenSSL through a new feature called `crypto_nossl`.

In particular, with `crypto_nossl` enabled, the `certs::snp::Verifiable` trait becomes implemented in pure Rust using the `p384`, `rsa`, `x509-cert`, and `sha2` crates, that is, without the use of OpenSSL, for the following types:
* `&certs::snp::Chain`
* `&certs::snp::ca::Chain`
* `(&certs::snp::Certificate, &certs::snp::Certificate)`
* `(&certs::snp::Chain, &firmware::guest::AttestationReport)`

This addresses https://github.com/virtee/sev/issues/109.

#### Tests and Github Workflows
* Adapts the feature gate for the SNP tests in `tests/certs.rs` so that those tests are run if either `openssl` or `crypto_nossl` is enabled.
* Adds negative tests for the SNP chain and report.
* Adds a `sw-crypto_nossl` test Github workflow to also perform the various cargo tests for the `crypto_nossl` feature.
* Splits the `cargo clippy` lint Github workflow into `cargo clippy openssl` and `cargo clippy crypto_nossl`, because currently the original workflow uses `--all-features`, which is not possible any more because `openssl` and `crypto_nossl` are mutually exclusive.

#### Feature & Compatibility
* `crypto_nossl` is not enabled by default and must be enabled manually if needed.
* `crypto_nossl` is _mutually exclusive_ with the existing `openssl` feature. If both are enabled at the same time, an explicit compiler error indicates that the two are incompatible. With this, a library user who wants to verify an SNP attestation report has to make a conscious decision as to whether OpenSSL shall be used for the verification or not. If OpenSSL shall be used, `openssl` is enabled. If it is OK not to use OpenSSL for verification, then `crypto_nossl` can be enabled.
* The feature name `crypto_nossl` is chosen deliberately as it makes it very explicit for library users that OpenSSL would _not_ be used for cryptographic verification.
* The existing OpenSSL-based implementation and API remains entirely unchanged. Existing library users are unaffected by this new feature, no matter if they currently have `openssl` enabled or not.

#### Misc
Removes the `pub use crate::firmware::host::Firmware;` re-export in `src/firmware/host/types/sev.rs` because this triggers an `error: unused import: crate::firmware::host::Firmware` in `src/firmware/host/types/sev.rs:6:9` in the clippy jobs. This seems to be a new clippy lint introduced in `1.75.0-nightly`, which is currently used by the Github workflow.