### PR TITLE
Add public getters for SNP ECDSA signature

### DIFF
--- a/src/certs/snp/ecdsa/mod.rs
+++ b/src/certs/snp/ecdsa/mod.rs
@@ -32,6 +32,18 @@ pub struct Signature {
     _reserved: [u8; 512 - R_S_SIZE],
 }
 
+impl Signature {
+    /// Returns the signatures `r` component
+    pub fn r(&self) -> &[u8; 72] {
+        &self.r
+    }
+
+    /// Returns the signatures `s` component
+    pub fn s(&self) -> &[u8; 72] {
+        &self.s
+    }
+}
+
 impl std::fmt::Debug for Signature {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
Adds public getters to the (also public) `crate::certs::snp::ecdsa::Signature`.

This allows for manual verification of an `AttestationReport`'s signature outside of the crate, for example for use cases where the attestation report shall be verified without OpenSSL (that is, without the `openssl` feature).

An alternative approach would be to simply make the fields `r` and `s` public, given that the attestation report's `signature` field is also public.

This would address issue #109. Another, more involved but much more comprehensive, approach of addressing issue #109 is drafted in PR https://github.com/virtee/sev/pull/111. Regardless of #111, adding public getters to the signature may be desirable anyway.