### PR TITLE
ext_config: Fixes config only operations.

### DIFF
--- a/src/firmware/host/types/snp.rs
+++ b/src/firmware/host/types/snp.rs
@@ -257,11 +257,11 @@ impl TryFrom<ExtConfig> for FFI::types::SnpGetExtConfig {
         let mut certs_address: u64 = 0u64;
         let certs_len: u32 = value.certs_len;
 
-        if let Some(config) = value.config {
-            config_address = &config as *const Config as u64;
+        if let Some(ref config) = value.config {
+            config_address = config as *const Config as u64;
         }
 
-        if let Some(certs) = value.certs {
+        if let Some(ref certs) = value.certs {
             certs_address = certs.as_ptr() as u64;
         }
 
@@ -281,11 +281,11 @@ impl TryFrom<ExtConfig> for FFI::types::SnpSetExtConfig {
         let mut certs_address: u64 = 0u64;
         let certs_len: u32 = value.certs_len;
 
-        if let Some(config) = value.config {
-            config_address = &config as *const Config as u64;
+        if let Some(ref config) = value.config {
+            config_address = config as *const Config as u64;
         }
 
-        if let Some(certs) = value.certs {
+        if let Some(ref certs) = value.certs {
             certs_address = certs.as_ptr() as u64;
         }
 


### PR DESCRIPTION
Previously we were passing the u64 value of the pointer to the vector of bytes the extended report certificates were being loaded from. However, when handling the case of an extended configuration only, because the pointer value of an empty vector is not 0, this was causing an error in the kernel when attempting to access the "pointer" being provided. By modifying the underlying type of `bytes` to `Option<Vec<u8>>`, it allows the default value to be set to `None`, and conditionally update the extended config `certs_address` field when certificate bytes are present.