### PR TITLE
Changing API for kernel 6.6 new IOCTL structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "2.0.2"
+version = "3.0.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTee Project Developers",

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -196,7 +196,11 @@ impl Firmware {
         Ok(platform_status)
     }
 
-    /// Commit the current SNP firmware
+    /// The firmware will perform the following actions:  
+    /// - Set the CommittedTCB to the CurrentTCB of the current firmware.  
+    /// - Set the CommittedVersion to the FirmwareVersion of the current firmware.  
+    /// - Sets the ReportedTCB to the CurrentTCB.  
+    /// - Deletes the VLEK hashstick if the ReportedTCB changed.
     ///
     /// # Example:
     /// ```ignore
@@ -222,57 +226,16 @@ impl Firmware {
     /// );
     /// let mut firmware: Firmware = Firmware::open().unwrap();
     ///
-    /// let status: bool = firmware.set_ext_config(configuration).unwrap();
+    /// let status: bool = firmware.snp_set_config(configuration).unwrap();
     /// ```
     #[cfg(feature = "snp")]
     pub fn snp_set_config(&mut self, new_config: Config) -> Result<(), UserApiError> {
-
-        SNP_SET_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut new_config.try_into()?))?;
+        SNP_SET_CONFIG.ioctl(
+            &mut self.0,
+            &mut Command::from_mut(&mut new_config.try_into()?),
+        )?;
 
         Ok(())
-    }
-
-    /// Start SNP configuration process
-    ///
-    /// # Example:
-    /// ```ignore
-    /// let mut firmware: Firmware = Firmware::open().unwrap();
-    ///
-    /// let config_id: configTransaction = firmware.snp_set_config_start().unwrap();
-    /// ```
-    #[cfg(feature = "snp")]
-    pub fn snp_set_config_start(&mut self) -> Result<ConfigTransaction, UserApiError> {
-
-        let mut config_start: FFI::types::SnpSetConfigStart = Default::default();
-
-        SNP_SET_CONFIG_START.ioctl(&mut self.0, &mut Command::from_mut(&mut config_start))?;
-
-        Ok(config_start.try_into()?)
-    }
-
-    /// End SNP configuration process
-    ///
-    /// # Example:
-    /// ```ignore
-    /// let mut firmware: Firmware = Firmware::open().unwrap();
-    ///
-    /// let start_config_id: configTransaction = firmware.snp_set_config_start().unwrap();
-    /// 
-    /// let end_config_id: configTransaction = firmware.snp_set_config_end().unwrap();
-    /// 
-    /// // if start and end error id's don't match, assume something process failed and start again. 
-    /// if start_config_id != end_config_id {
-    ///     Err(eprintln!("start id and end id don't match!""))
-    /// }
-    /// ```
-    #[cfg(feature = "snp")]
-    pub fn snp_set_config_end(&mut self) -> Result<ConfigTransaction, UserApiError> {
-        
-        let mut config_end: FFI::types::SnpSetConfigEnd = Default::default();
-
-        SNP_SET_CONFIG_END.ioctl(&mut self.0, &mut Command::from_mut(&mut config_end))?;
-
-        Ok(config_end.try_into()?)
     }
 }
 

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -38,6 +38,10 @@ use std::mem::MaybeUninit;
 #[cfg(target_os = "linux")]
 use std::convert::TryInto;
 
+#[cfg(feature = "snp")]
+#[cfg(target_os = "linux")]
+use super::linux::host::types::SnpCommit;
+
 /// The CPU-unique identifier for the platform.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Identifier(pub Vec<u8>);
@@ -192,107 +196,83 @@ impl Firmware {
         Ok(platform_status)
     }
 
-    /// Reset the configuration of the AMD secure processor. Useful for resetting the committed_tcb.
+    /// Commit the current SNP firmware
+    ///
     /// # Example:
     /// ```ignore
-    /// use snp::firmware::host::*;
-    ///
     /// let mut firmware: Firmware = Firmware::open().unwrap();
     ///
-    /// firmware.reset_config().unwrap();
+    /// let status: bool = firmware.snp_commit().unwrap();
     /// ```
     #[cfg(feature = "snp")]
-    pub fn snp_reset_config(&mut self) -> Result<(), UserApiError> {
-        let config: Config = Config::new(TcbVersion::default(), 0);
-
-        let mut config: FFI::types::SnpSetExtConfig = FFI::types::SnpSetExtConfig {
-            config_address: &config as *const Config as u64,
-            certs_address: 0,
-            certs_len: 0,
-        };
-
-        SNP_SET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut config))?;
+    pub fn snp_commit(&mut self) -> Result<(), UserApiError> {
+        let mut buf: SnpCommit = Default::default();
+        SNP_COMMIT.ioctl(&mut self.0, &mut Command::from_mut(&mut buf))?;
 
         Ok(())
     }
-    /// Fetch the SNP Extended Configuration.
+
+    /// Set the SNP Configuration.
     ///
     /// # Example:
     /// ```ignore
-    /// let mut firmware: Firmware = Firmware::open().unwrap();
-    ///
-    /// let status: ExtConfig = firmware.get_ext_config().unwrap();
-    /// ```
-    #[cfg(feature = "snp")]
-    pub fn snp_get_ext_config(&mut self) -> Result<ExtConfig, UserApiError> {
-        let mut raw_buf: Vec<u8> = vec![0; _4K_PAGE];
-        let mut config = FFI::types::SnpGetExtConfig {
-            config_address: 0,
-            certs_address: raw_buf.as_mut_ptr() as *mut CertTableEntry as u64,
-            certs_len: _4K_PAGE as u32,
-        };
-
-        SNP_GET_EXT_CONFIG
-            .ioctl(&mut self.0, &mut Command::from_mut(&mut config))
-            .or_else(|err| {
-                // If the error occurred because the buffer was to small, it will have changed
-                // the buffer. If it has, we will attempt to resize it.
-                if config.certs_len <= _4K_PAGE as u32 {
-                    return Err(err);
-                }
-
-                raw_buf = vec![0; config.certs_len as usize];
-                config.certs_address = raw_buf.as_ptr() as *const CertTableEntry as u64;
-                SNP_GET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut config))
-            })?;
-
-        config.try_into().map_err(|op: uuid::Error| op.into())
-    }
-
-    /// Set the SNP Extended Configuration.
-    ///
-    /// # Example:
-    /// ```ignore
-    /// pub const ARK: &[u8] = include_bytes!("../../certs/builtin/milan/ark.pem");
-    /// pub const ASK: &[u8] = include_bytes!("../../certs/builtin/genoa/ask.pem");
-    /// pub const VCEK: &[u8] = include_bytes!("vcek.pem");
-    ///
     /// let configuration = Config::new(
     ///     TcbVersion::new(3, 0, 10, 169),
     ///     0,
     /// );
-    ///
-    /// // Generate a vector of certificates to store in hypervisor memory.
-    /// let certificates = vec![
-    ///     CertTableEntry::new(CertType::ARK, ARK.to_vec()),
-    ///     CertTableEntry::new(CertType::ASK, ASK.to_vec()),
-    ///     CertTableEntry::new(CertType::VCEK, VCEK.to_vec()),
-    /// ];
-    ///
-    /// // Call the `new` constructor to generate the extended configuration.
-    /// let ext_config: ExtConfig = ExtConfig::new(configuration, certificates);
-    ///
     /// let mut firmware: Firmware = Firmware::open().unwrap();
     ///
-    /// let status: bool = firmware.set_ext_config(ext_config).unwrap();
+    /// let status: bool = firmware.set_ext_config(configuration).unwrap();
     /// ```
     #[cfg(feature = "snp")]
-    pub fn snp_set_ext_config(&mut self, mut new_config: ExtConfig) -> Result<(), UserApiError> {
-        let mut opt_bytes: Option<Vec<u8>> = None;
+    pub fn snp_set_config(&mut self, new_config: Config) -> Result<(), UserApiError> {
 
-        if let Some(ref mut certificates) = new_config.certs {
-            opt_bytes = Some(FFI::types::CertTableEntry::uapi_to_vec_bytes(certificates)?);
-        }
-
-        let mut new_ext_config: FFI::types::SnpSetExtConfig = new_config.try_into()?;
-
-        if let Some(ref mut bytes) = opt_bytes {
-            new_ext_config.certs_address = bytes.as_mut_ptr() as u64;
-        }
-
-        SNP_SET_EXT_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut new_ext_config))?;
+        SNP_SET_CONFIG.ioctl(&mut self.0, &mut Command::from_mut(&mut new_config.try_into()?))?;
 
         Ok(())
+    }
+
+    /// Start SNP configuration process
+    ///
+    /// # Example:
+    /// ```ignore
+    /// let mut firmware: Firmware = Firmware::open().unwrap();
+    ///
+    /// let config_id: configTransaction = firmware.snp_set_config_start().unwrap();
+    /// ```
+    #[cfg(feature = "snp")]
+    pub fn snp_set_config_start(&mut self) -> Result<ConfigTransaction, UserApiError> {
+
+        let mut config_start: FFI::types::SnpSetConfigStart = Default::default();
+
+        SNP_SET_CONFIG_START.ioctl(&mut self.0, &mut Command::from_mut(&mut config_start))?;
+
+        Ok(config_start.try_into()?)
+    }
+
+    /// End SNP configuration process
+    ///
+    /// # Example:
+    /// ```ignore
+    /// let mut firmware: Firmware = Firmware::open().unwrap();
+    ///
+    /// let start_config_id: configTransaction = firmware.snp_set_config_start().unwrap();
+    /// 
+    /// let end_config_id: configTransaction = firmware.snp_set_config_end().unwrap();
+    /// 
+    /// // if start and end error id's don't match, assume something process failed and start again. 
+    /// if start_config_id != end_config_id {
+    ///     Err(eprintln!("start id and end id don't match!""))
+    /// }
+    /// ```
+    #[cfg(feature = "snp")]
+    pub fn snp_set_config_end(&mut self) -> Result<ConfigTransaction, UserApiError> {
+        
+        let mut config_end: FFI::types::SnpSetConfigEnd = Default::default();
+
+        SNP_SET_CONFIG_END.ioctl(&mut self.0, &mut Command::from_mut(&mut config_end))?;
+
+        Ok(config_end.try_into()?)
     }
 }
 

--- a/src/firmware/host/types/snp.rs
+++ b/src/firmware/host/types/snp.rs
@@ -126,8 +126,16 @@ impl CertTableEntry {
     }
 
     /// Builds a Kernel formatted CertTable for sending the certificate content to the PSP.
-    pub fn cert_table_to_vec_bytes(table: &Vec<Self>) -> Result<Vec<u8>, CertError> {
-        FFI::types::CertTableEntry::uapi_to_vec_bytes(table)
+    pub fn cert_table_to_vec_bytes(table: &[Self]) -> Result<Vec<u8>, CertError> {
+        FFI::types::CertTableEntry::uapi_to_vec_bytes(&table.to_vec())
+    }
+
+    /// Takes in bytes in kernel CertTable format and returns in user API CertTable format.
+    pub fn vec_bytes_to_cert_table(mut bytes: Vec<u8>) -> Result<Vec<Self>, CertError> {
+        let cert_bytes_ptr: *mut FFI::types::CertTableEntry =
+            bytes.as_mut_ptr() as *mut FFI::types::CertTableEntry;
+
+        Ok(unsafe { FFI::types::CertTableEntry::parse_table(cert_bytes_ptr).unwrap() })
     }
 }
 

--- a/src/firmware/linux/host/ioctl.rs
+++ b/src/firmware/linux/host/ioctl.rs
@@ -14,7 +14,6 @@ use std::marker::PhantomData;
 
 use iocuddle::*;
 
-
 // These enum ordinal values are defined in the Linux kernel
 // source code: include/uapi/linux/psp-sev.h
 #[cfg(all(feature = "sev", feature = "snp"))]
@@ -33,8 +32,6 @@ impl_const_id! {
     SnpPlatformStatus = 0x9,
     SnpCommit = 0xA,
     SnpSetConfig = 0xB,
-    SnpSetConfigStart = 0xC,
-    SnpSetConfigEnd = 0xD
 }
 
 #[cfg(all(feature = "sev", not(feature = "snp")))]
@@ -59,9 +56,6 @@ impl_const_id! {
     SnpPlatformStatus = 0x9,
     SnpCommit = 0xA,
     SnpSetConfig = 0xB,
-    SnpSetConfigStart = 0xC,
-    SnpSetConfigEnd = 0xD
-    
 }
 
 const SEV: Group = Group::new(b'S');
@@ -106,29 +100,19 @@ pub const GET_ID: Ioctl<WriteRead, &Command<GetId<'_>>> = unsafe { SEV.write_rea
 pub const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<SnpPlatformStatus>> =
     unsafe { SEV.write_read(0) };
 
-/// Commit the currently installed firmware.
+/// The firmware will perform the following actions:
+/// - Set the CommittedTCB to the CurrentTCB of the current firmware.
+/// - Set the CommittedVersion to the FirmwareVersion of the current firmware.
+/// - Sets the ReportedTCB to the CurrentTCB.
+/// - Deletes the VLEK hashstick if the ReportedTCB changed.
 /// C IOCTL calls -> sev_ioctl_do_snp_commit
 #[cfg(feature = "snp")]
-pub const SNP_COMMIT: Ioctl<WriteRead, &Command<SnpCommit>> =
-    unsafe {SEV.write_read(0)};
+pub const SNP_COMMIT: Ioctl<WriteRead, &Command<SnpCommit>> = unsafe { SEV.write_read(0) };
 
 /// Set the system-wide configuration such as reported TCB version in the attestation report
 /// C IOCTL calls -> sev_ioctl_do_snp_set_config
 #[cfg(feature = "snp")]
-pub const SNP_SET_CONFIG: Ioctl<WriteRead, &Command<SnpSetConfig>> =
-    unsafe {SEV.write_read(0)};
-
-/// Issued prior to performing any updates to the reported TCB or certificate data.
-/// C IOCTL calls -> sev_ioctl_do_snp_set_config_start
-#[cfg(feature = "snp")]
-pub const SNP_SET_CONFIG_START: Ioctl<WriteRead, &Command<SnpSetConfigStart>> =
-    unsafe {SEV.write_read(0)};
-
-/// Issued to resume normal servicing of extended guest requests.
-/// C IOCTL calls -> sev_ioctl_do_snp_set_config_end
-#[cfg(feature = "snp")]
-pub const SNP_SET_CONFIG_END: Ioctl<WriteRead, &Command<SnpSetConfigEnd>> =
-    unsafe {SEV.write_read(0)};
+pub const SNP_SET_CONFIG: Ioctl<WriteRead, &Command<SnpSetConfig>> = unsafe { SEV.write_read(0) };
 
 /// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
 /// used to pass arguments to the SEV ioctl implementation.

--- a/src/firmware/linux/host/ioctl.rs
+++ b/src/firmware/linux/host/ioctl.rs
@@ -14,6 +14,7 @@ use std::marker::PhantomData;
 
 use iocuddle::*;
 
+
 // These enum ordinal values are defined in the Linux kernel
 // source code: include/uapi/linux/psp-sev.h
 #[cfg(all(feature = "sev", feature = "snp"))]
@@ -30,8 +31,10 @@ impl_const_id! {
     GetId<'_> = 0x8, /* GET_ID2 is 0x8, the deprecated GET_ID ioctl is 0x7 */
 
     SnpPlatformStatus = 0x9,
-    SnpSetExtConfig = 0xA,
-    SnpGetExtConfig = 0xB,
+    SnpCommit = 0xA,
+    SnpSetConfig = 0xB,
+    SnpSetConfigStart = 0xC,
+    SnpSetConfigEnd = 0xD
 }
 
 #[cfg(all(feature = "sev", not(feature = "snp")))]
@@ -54,8 +57,11 @@ impl_const_id! {
 
     GetId<'_> = 0x8, /* GET_ID2 is 0x8, the deprecated GET_ID ioctl is 0x7 */
     SnpPlatformStatus = 0x9,
-    SnpSetExtConfig = 0xA,
-    SnpGetExtConfig = 0xB,
+    SnpCommit = 0xA,
+    SnpSetConfig = 0xB,
+    SnpSetConfigStart = 0xC,
+    SnpSetConfigEnd = 0xD
+    
 }
 
 const SEV: Group = Group::new(b'S');
@@ -100,16 +106,29 @@ pub const GET_ID: Ioctl<WriteRead, &Command<GetId<'_>>> = unsafe { SEV.write_rea
 pub const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<SnpPlatformStatus>> =
     unsafe { SEV.write_read(0) };
 
-/// Set the SNP Extended Configuration Settings.
-/// C IOCTL calls -> sev_ioctl_snp_set_config
+/// Commit the currently installed firmware.
+/// C IOCTL calls -> sev_ioctl_do_snp_commit
 #[cfg(feature = "snp")]
-pub const SNP_SET_EXT_CONFIG: Ioctl<WriteRead, &Command<SnpSetExtConfig>> =
-    unsafe { SEV.write_read(0) };
+pub const SNP_COMMIT: Ioctl<WriteRead, &Command<SnpCommit>> =
+    unsafe {SEV.write_read(0)};
 
-/// Get the SNP Extended Configuration Settings.
+/// Set the system-wide configuration such as reported TCB version in the attestation report
+/// C IOCTL calls -> sev_ioctl_do_snp_set_config
 #[cfg(feature = "snp")]
-pub const SNP_GET_EXT_CONFIG: Ioctl<WriteRead, &Command<SnpGetExtConfig>> =
-    unsafe { SEV.write_read(0) };
+pub const SNP_SET_CONFIG: Ioctl<WriteRead, &Command<SnpSetConfig>> =
+    unsafe {SEV.write_read(0)};
+
+/// Issued prior to performing any updates to the reported TCB or certificate data.
+/// C IOCTL calls -> sev_ioctl_do_snp_set_config_start
+#[cfg(feature = "snp")]
+pub const SNP_SET_CONFIG_START: Ioctl<WriteRead, &Command<SnpSetConfigStart>> =
+    unsafe {SEV.write_read(0)};
+
+/// Issued to resume normal servicing of extended guest requests.
+/// C IOCTL calls -> sev_ioctl_do_snp_set_config_end
+#[cfg(feature = "snp")]
+pub const SNP_SET_CONFIG_END: Ioctl<WriteRead, &Command<SnpSetConfigEnd>> =
+    unsafe {SEV.write_read(0)};
 
 /// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
 /// used to pass arguments to the SEV ioctl implementation.

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -108,7 +108,7 @@ impl CertTableEntry {
     /// ```
     ///
     #[cfg(target_os = "linux")]
-    pub fn uapi_to_vec_bytes(table: &Vec<UAPI::CertTableEntry>) -> Result<Vec<u8>, CertError> {
+    pub fn uapi_to_vec_bytes(table: &[UAPI::CertTableEntry]) -> Result<Vec<u8>, CertError> {
         // Create the vector to return for later.
         let mut bytes: Vec<u8> = vec![];
 
@@ -216,7 +216,9 @@ impl CertTableEntry {
 #[cfg(feature = "snp")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[repr(C, packed)]
-pub struct SnpCommit(u32);
+pub struct SnpCommit {
+    pub buffer: u32,
+}
 
 /// Sets the system wide configuration values for SNP.
 #[cfg(feature = "snp")]
@@ -229,7 +231,7 @@ pub struct SnpSetConfig {
     /// mask_id [0] : whether chip id is present in attestation reports or not  
     /// mask_id [1]: whether attestation reports are signed or not
     /// rsvd [2:31]: reserved
-    pub mask_id: u32,
+    pub mask_id: UAPI::MaskId,
 
     /// Reserved. Must be zero.
     reserved: [u8; 52],

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -211,14 +211,12 @@ impl CertTableEntry {
     }
 }
 
-/// SNP_COMMIT structure
+/// SNP_COMMIT structure  
+/// - length: length of the command buffer read by the PSP  
 #[cfg(feature = "snp")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[repr(C,packed)]
-pub struct SnpCommit{
-    /// len of the command buffer read by the PSP
-    length: u32
-}
+#[repr(C, packed)]
+pub struct SnpCommit(u32);
 
 /// Sets the system wide configuration values for SNP.
 #[cfg(feature = "snp")]
@@ -228,8 +226,8 @@ pub struct SnpSetConfig {
     /// The TCB_VERSION to report in guest attestation reports.
     pub reported_tcb: UAPI::TcbVersion,
 
-    /// mask_chip_id [0] : whether chip id is present in attestation reports or not
-    /// mask_chip_key [1]: whether attestation reports are signed or not
+    /// mask_id [0] : whether chip id is present in attestation reports or not  
+    /// mask_id [1]: whether attestation reports are signed or not
     /// rsvd [2:31]: reserved
     pub mask_id: u32,
 
@@ -246,25 +244,6 @@ impl Default for SnpSetConfig {
         }
     }
 }
-
-/// Metadata for config transactions.
-#[cfg(feature = "snp")]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[repr(C, packed)]
-pub struct SnpSetConfigStart {
-    /// The ID of the transaction started by a call to SNP_SET_CONFIG_START.
-    pub id: u64
-}
-
-/// Metadata for config transactions.
-#[cfg(feature = "snp")]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[repr(C, packed)]
-pub struct SnpSetConfigEnd {
-    /// The ID of the transaction ended by a call SNP_SET_CONFIG_END.
-    pub id: u64
-}
-
 
 #[cfg(test)]
 mod test {

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -211,33 +211,60 @@ impl CertTableEntry {
     }
 }
 
-#[repr(C)]
-pub struct SnpSetExtConfig {
-    /// Address of the Config or 0 when reported_tcb does not need
-    /// to be updated.
-    pub config_address: u64,
-
-    /// Address of extended guest request [`CertTableEntry`] buffer or 0 when
-    /// previous certificate(s) should be removed via SNP_SET_EXT_CONFIG.
-    pub certs_address: u64,
-
-    /// 4K-page aligned length of the buffer holding certificates to be cached.
-    pub certs_len: u32,
+/// SNP_COMMIT structure
+#[cfg(feature = "snp")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[repr(C,packed)]
+pub struct SnpCommit{
+    /// len of the command buffer read by the PSP
+    length: u32
 }
 
-#[repr(C)]
-pub struct SnpGetExtConfig {
-    /// Address of the Config or 0 when reported_tcb should not be
-    /// fetched.
-    pub config_address: u64,
+/// Sets the system wide configuration values for SNP.
+#[cfg(feature = "snp")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, packed)]
+pub struct SnpSetConfig {
+    /// The TCB_VERSION to report in guest attestation reports.
+    pub reported_tcb: UAPI::TcbVersion,
 
-    /// Address of extended guest request [`CertTableEntry`] buffer or 0 when
-    /// certificate(s) should not be fetched.
-    pub certs_address: u64,
+    /// mask_chip_id [0] : whether chip id is present in attestation reports or not
+    /// mask_chip_key [1]: whether attestation reports are signed or not
+    /// rsvd [2:31]: reserved
+    pub mask_id: u32,
 
-    /// 4K-page aligned length of the buffer which will hold the fetched certificates.
-    pub certs_len: u32,
+    /// Reserved. Must be zero.
+    reserved: [u8; 52],
 }
+
+impl Default for SnpSetConfig {
+    fn default() -> Self {
+        Self {
+            reported_tcb: Default::default(),
+            mask_id: Default::default(),
+            reserved: [0; 52],
+        }
+    }
+}
+
+/// Metadata for config transactions.
+#[cfg(feature = "snp")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[repr(C, packed)]
+pub struct SnpSetConfigStart {
+    /// The ID of the transaction started by a call to SNP_SET_CONFIG_START.
+    pub id: u64
+}
+
+/// Metadata for config transactions.
+#[cfg(feature = "snp")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[repr(C, packed)]
+pub struct SnpSetConfigEnd {
+    /// The ID of the transaction ended by a call SNP_SET_CONFIG_END.
+    pub id: u64
+}
+
 
 #[cfg(test)]
 mod test {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -121,9 +121,7 @@ mod sev {
 
 #[cfg(feature = "snp")]
 mod snp {
-    use sev::firmware::host::{
-        Config, Firmware, SnpPlatformStatus, TcbVersion,
-    };
+    use sev::firmware::host::{Config, Firmware, SnpPlatformStatus, TcbVersion};
 
     use serial_test::serial;
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -121,7 +121,7 @@ mod sev {
 
 #[cfg(feature = "snp")]
 mod snp {
-    use sev::firmware::host::{Config, Firmware, SnpPlatformStatus, TcbVersion};
+    use sev::firmware::host::{Config, Firmware, MaskId, SnpPlatformStatus, TcbVersion};
 
     use serial_test::serial;
 
@@ -182,7 +182,7 @@ mod snp {
     #[serial]
     fn set_config() {
         let mut fw: Firmware = Firmware::open().unwrap();
-        let new_config = Config::new(TcbVersion::new(1, 0, 1, 1), 31);
+        let new_config = Config::new(TcbVersion::new(1, 0, 1, 1), MaskId(31));
         fw.snp_set_config(new_config).unwrap();
     }
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -122,7 +122,7 @@ mod sev {
 #[cfg(feature = "snp")]
 mod snp {
     use sev::firmware::host::{
-        CertTableEntry, CertType, Config, ExtConfig, Firmware, SnpPlatformStatus, TcbVersion,
+        Config, Firmware, SnpPlatformStatus, TcbVersion,
     };
 
     use serial_test::serial;
@@ -171,74 +171,20 @@ mod snp {
         );
     }
 
-    fn build_ext_config(cert: bool, cfg: bool) -> ExtConfig {
-        let test_cfg: Config = Config::new(TcbVersion::new(1, 0, 1, 1), 31);
-
-        let cert_table: Vec<CertTableEntry> = vec![
-            CertTableEntry::new(CertType::ARK, vec![1; 28]),
-            CertTableEntry::new(CertType::ASK, vec![1; 28]),
-        ];
-
-        match (cert, cfg) {
-            (true, true) => ExtConfig::new(test_cfg, cert_table),
-            (true, false) => ExtConfig::new_certs_only(cert_table),
-            (false, true) => ExtConfig::new_config_only(test_cfg),
-            (false, false) => ExtConfig::default(),
-        }
+    #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+    #[test]
+    #[serial]
+    fn commit_snp() {
+        let mut fw: Firmware = Firmware::open().unwrap();
+        fw.snp_commit().unwrap();
     }
 
     #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
     #[test]
     #[serial]
-    fn set_ext_config_std() {
+    fn set_config() {
         let mut fw: Firmware = Firmware::open().unwrap();
-        let new_config: ExtConfig = build_ext_config(true, true);
-        fw.snp_set_ext_config(new_config).unwrap();
-        fw.snp_reset_config().unwrap();
-    }
-
-    #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
-    #[test]
-    #[serial]
-    fn set_ext_config_certs_only() {
-        let mut fw: Firmware = Firmware::open().unwrap();
-        let new_config: ExtConfig = build_ext_config(true, false);
-        fw.snp_set_ext_config(new_config).unwrap();
-        fw.snp_reset_config().unwrap();
-    }
-
-    #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
-    #[test]
-    #[serial]
-    fn set_ext_config_cfg_only() {
-        let mut fw: Firmware = Firmware::open().unwrap();
-        let new_config: ExtConfig = build_ext_config(false, true);
-        fw.snp_set_ext_config(new_config).unwrap();
-        fw.snp_reset_config().unwrap();
-    }
-
-    #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
-    #[test]
-    #[serial]
-    fn set_ext_invalid_config_std() {
-        let mut fw: Firmware = Firmware::open().unwrap();
-        let platform_status: SnpPlatformStatus = fw.snp_platform_status().unwrap();
-
-        // Using Current TCB as Committed TCB is not available at the moment,
-        // but ideally we would like to check Reported TCB <= Committed TCB, only.
-        let mut invalid_tcb: TcbVersion = platform_status.platform_tcb_version;
-        invalid_tcb.snp += 1;
-        fw.snp_set_ext_config(ExtConfig::new_config_only(Config::new(invalid_tcb, 0)))
-            .unwrap();
-        fw.snp_reset_config().unwrap();
-    }
-
-    #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
-    #[test]
-    #[serial]
-    fn get_ext_config_std() {
-        let mut fw: Firmware = Firmware::open().unwrap();
-        let hw_config: ExtConfig = fw.snp_get_ext_config().unwrap();
-        println!("{:?}", hw_config);
+        let new_config = Config::new(TcbVersion::new(1, 0, 1, 1), 31);
+        fw.snp_set_config(new_config).unwrap();
     }
 }


### PR DESCRIPTION
In new kernel 6.6 the SNP IOCTL structure changed. We are completely removing the deprecated extended config and IOCTLs. I also bumped the release to 3.0 in this PR. THIS WILL NOT WORK ON KERNELS BEFORE SNP 6.6.

The new IOCTLS and it's uses have been added to this PR. 

SNP_SET_CONFIG_START and SNP_SET_CONFIG_END will be revised in later kernel patches according to Michael Roth. So those will probably be changed. Should we include those in this PR? 

Also certificates are no longer handled by firmware, but they will be handled by the QEMU command line. Do we want to move the kernel version of CertTableEntry to the UAPI? that way users can create the appropriate versions of that? For now there will be some compiling errors because that struct is not being used, but I don't think it has been deprecated yet. 

Everything related to the previous ioctls and extended_config has been deleted.

Please share thoughts and comments on the topic.