### PR TITLE
Fix MacOS & Windows compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ on: [push, pull_request]
 name: test
 jobs:
   sw-openssl:
-    name: sw openssl ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
-    runs-on: ubuntu-latest
+    name: sw openssl ${{ matrix.runner }} ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -14,6 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner:
+          - ubuntu-latest
+          - macos-12
         toolchain:
           - 1.70.0
           - stable
@@ -25,8 +28,8 @@ jobs:
           - openssl
 
   sw-crypto_nossl:
-    name: sw crypto_nossl ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
-    runs-on: ubuntu-latest
+    name: sw crypto_nossl ${{ matrix.runner }} ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -36,6 +39,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner:
+          - ubuntu-latest
+          - macos-12
+          - windows-latest
         toolchain:
           - 1.70.0
           - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -264,9 +264,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -289,15 +289,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -306,27 +306,27 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hex"
@@ -410,19 +410,20 @@ checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
 name = "kvm-bindings"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe70e65a5b092161d17f5005b66e5eefe7a94a70c332e755036fc4af78c4e79"
+checksum = "081fbd8164229a990fbf24a1f35d287740db110c2b5d42addf460165f1b0e032"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdde2b46ee7b6587ef79f751019c4726c4f2d3e4628df5d69f3f9c5cb6c6bd4"
+checksum = "9002dff009755414f22b962ec6ae6980b07d6d8b06e5297b1062019d72bd6a8c"
 dependencies = [
+ "bitflags 2.4.2",
  "kvm-bindings",
  "libc",
  "vmm-sys-util",
@@ -451,9 +452,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -467,9 +468,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "num-bigint-dig"
@@ -531,7 +532,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -593,13 +594,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -725,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1037,9 +1038,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
+checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ x509-cert = { version = "0.2.5", optional = true }
 byteorder = "1.4.3"
 base64 = "0.22.0"
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 kvm-ioctls = ">=0.12"
+
+[dev-dependencies]
 kvm-bindings = ">=0.6"
 serial_test = "3.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Firmware (SNP)] (https://www.amd.com/content/dam/amd/en/documents/epyc-technical
 
 ### SEV APIs
 
-The Linux kernel exposes two technically distinct AMD SEV APIs:
+The linux kernel exposes two technically distinct AMD SEV APIs:
 
 1. An API for managing the SEV platform itself
 2. An API for managing SEV-enabled KVM virtual machines
@@ -21,7 +21,7 @@ code through a flexible and type-safe high-level interface.
 
 ### SNP ABIs
 
-Like SEV, the Linux kernel exposes another two different AMD SEV-SNP ABIs:
+Like SEV, the linux kernel exposes another two different AMD SEV-SNP ABIs:
 
 1. An ABI for managing the SEV-SNP platform itself
 2. An ABI for managing SEV-SNP enabled KVM virtual machines
@@ -62,7 +62,7 @@ and enabling both at the same time leads to a compiler error.
 
 ### Remarks
 
-Note that the Linux kernel provides access to these APIs through a set
+Note that the linux kernel provides access to these APIs through a set
 of `ioctl`s that are meant to be called on device nodes (`/dev/kvm` and
 `/dev/sev`, to be specific). As a result, these `ioctl`s form the substrate
 of the `sev` crate. Binaries that result from consumers of this crate are

--- a/src/firmware/host/types/snp.rs
+++ b/src/firmware/host/types/snp.rs
@@ -5,7 +5,10 @@ pub use crate::firmware::linux::host::types::RawData;
 
 pub(crate) use crate::firmware::linux::host as FFI;
 
-use crate::{firmware::host::CertError, Version};
+use crate::Version;
+
+#[cfg(target_os = "linux")]
+use crate::error::CertError;
 
 use std::{
     convert::{TryFrom, TryInto},
@@ -172,11 +175,13 @@ impl CertTableEntry {
     }
 
     /// Builds a Kernel formatted CertTable for sending the certificate content to the PSP.
+    #[cfg(target_os = "linux")]
     pub fn cert_table_to_vec_bytes(table: &[Self]) -> Result<Vec<u8>, CertError> {
         FFI::types::CertTableEntry::uapi_to_vec_bytes(table)
     }
 
     /// Takes in bytes in kernel CertTable format and returns in user API CertTable format.
+    #[cfg(target_os = "linux")]
     pub fn vec_bytes_to_cert_table(bytes: &mut [u8]) -> Result<Vec<Self>, CertError> {
         let cert_bytes_ptr: *mut FFI::types::CertTableEntry =
             bytes.as_mut_ptr() as *mut FFI::types::CertTableEntry;

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -5,6 +5,7 @@ use crate::error::CertError;
 
 use crate::firmware::host as UAPI;
 
+#[cfg(target_os = "linux")]
 use uuid::Uuid;
 
 /// Raw certificate bytes (by pointer or Vec<u8>).
@@ -163,6 +164,7 @@ impl CertTableEntry {
     /// };
     /// ```
     ///
+    #[cfg(target_os = "linux")]
     pub unsafe fn parse_table(
         mut data: *mut CertTableEntry,
     ) -> Result<Vec<UAPI::CertTableEntry>, uuid::Error> {
@@ -305,6 +307,7 @@ mod test {
         }
     }
 
+    #[cfg(target_os = "linux")]
     mod cert_table_entry {
 
         use crate::firmware::host as UAPI;

--- a/src/measurement/gctx.rs
+++ b/src/measurement/gctx.rs
@@ -4,7 +4,10 @@ use std::convert::TryInto;
 
 use openssl::sha::sha384;
 
-use crate::{error::*, launch::snp::PageType};
+use crate::error::*;
+
+#[cfg(target_os = "linux")]
+use crate::launch::snp::PageType;
 
 // Launch digest size in bytes
 pub(crate) const LD_SIZE: usize = 384 / 8;
@@ -89,6 +92,7 @@ impl Gctx<Updating> {
 
     /// Update Lanunch digest type accprding to page type and guest physical address.
     /// Some Page types don't require data. Some page types just require size of the page.
+    #[cfg(target_os = "linux")]
     pub fn update_page(
         &mut self,
         page_type: PageType,

--- a/src/measurement/mod.rs
+++ b/src/measurement/mod.rs
@@ -3,7 +3,7 @@
 //! Everything one needs to calculate a launch measurement for a SEV encrypted confidential guest.
 //! This includes, GCTX, SEV-HASHES, VMSA and OVMF pages.
 
-#[cfg(all(feature = "snp", feature = "openssl"))]
+#[cfg(all(target_os = "linux", feature = "snp", feature = "openssl"))]
 pub mod gctx;
 
 #[cfg(any(feature = "sev", feature = "snp"))]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "sev")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 mod sev {
     use sev::cached_chain;
     use sev::{certs::sev::sev::Usage, firmware::host::Firmware, Build, Version};
@@ -119,7 +119,7 @@ mod sev {
     }
 }
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 mod snp {
     use sev::firmware::host::{Config, Firmware, MaskId, SnpPlatformStatus, TcbVersion};
 

--- a/tests/guest.rs
+++ b/tests/guest.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use sev::firmware::guest::*;
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 #[cfg_attr(not(has_sev_guest), ignore)]
 #[test]
 fn get_report() {
@@ -14,7 +14,7 @@ fn get_report() {
     fw.get_report(None, Some(unique_data), None).unwrap();
 }
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 #[cfg_attr(not(has_sev_guest), ignore)]
 #[test]
 fn get_ext_report() {
@@ -25,7 +25,7 @@ fn get_ext_report() {
     fw.get_ext_report(None, Some(unique_data), None).unwrap();
 }
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 #[cfg_attr(not(has_sev_guest), ignore)]
 #[test]
 fn get_derived_key() {

--- a/tests/id-block.rs
+++ b/tests/id-block.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "openssl")]
+#![cfg(all(feature = "openssl", target_os = "linux"))]
 
 use std::{
     convert::{TryFrom, TryInto},

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -2,31 +2,31 @@
 
 #![cfg(feature = "openssl")]
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use std::slice::from_raw_parts;
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use std::{convert::TryFrom, os::unix::io::AsRawFd};
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use sev::{cached_chain, firmware::host::Firmware, launch::sev::*, session::Session};
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use kvm_bindings::kvm_userspace_memory_region;
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use kvm_ioctls::{Kvm, VcpuExit};
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 use serial_test::serial;
 
 // has to be a multiple of 16
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 const CODE: &[u8; 16] = &[
     0xf4; 16 // hlt
 ];
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 #[cfg_attr(not(has_sev), ignore)]
 #[test]
 #[serial]

--- a/tests/measurement.rs
+++ b/tests/measurement.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "openssl")]
 
-#[cfg(feature = "snp")]
+#[cfg(all(target_os = "linux", feature = "snp"))]
 mod snp_tests {
     use sev::measurement::{
         snp::*,
@@ -389,7 +389,7 @@ mod snp_tests {
     }
 }
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 mod sev_tests {
     use sev::measurement::sev::*;
     // test regular sev-es

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "openssl")]
 
-#[cfg(feature = "sev")]
+#[cfg(all(target_os = "linux", feature = "sev"))]
 mod initialized {
     use ::sev::{certs::sev::builtin::naples::*, certs::sev::*, launch, session::Session};
     use codicon::Decoder;

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use std::slice::from_raw_parts_mut;
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use sev::firmware::host::Firmware;
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use sev::launch::snp::*;
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use kvm_bindings::kvm_userspace_memory_region;
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 use kvm_ioctls::{Kvm, VcpuExit};
 
 // one page of `hlt`
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 const CODE: &[u8; 4096] = &[
     0xf4; 4096 // hlt
 ];
 
-#[cfg(feature = "snp")]
+#[cfg(all(feature = "snp", target_os = "linux"))]
 #[cfg_attr(not(has_sev), ignore)]
 #[test]
 fn snp() {


### PR DESCRIPTION
The SEV library was compiling on MacOS & Windows previously. Recent commits have broken that. This PR fixes it. 
Also add MacOS & Windows runners in the CI workflow to keep MacOS & Windows support in the future