### PR TITLE
Expanding Guest Policy Fields

### DIFF
--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -399,15 +399,20 @@ bitfield! {
     /// the policy to the guest. The policy cannot be changed throughout the lifetime of the guest. The
     /// policy is also migrated with the guest and enforced by the destination platform firmware.
     ///
-    /// | Bit(s) | Name          | Description                                                                                       >
-    /// |--------|---------------|--------------------------------------------------------------------------------------------------->
-    /// | 7:0    | ABI_MINOR     | The minimum ABI minor version required for this guest to run.                                     >
-    /// | 15:8   | ABI_MAJOR     | The minimum ABI major version required for this guest to run.                                     >
-    /// | 16     | SMT           | 0: Host SMT usage is disallowed.<br>1: Host SMT usage is allowed.                                 >
-    /// | 17     | -             | Reserved. Must be one.                                                                            >
-    /// | 18     | MIGRATE_MA    | 0: Association with a migration agent is disallowed.<br>1: Association with a migration agent is a>
-    /// | 19     | DEBUG         | 0: Debugging is disallowed.<br>1: Debugging is allowed.                                           >
-    /// | 20     | SINGLE_SOCKET | 0: Guest can be activated on multiple sockets.<br>1: Guest can only be activated on one socket.   >
+    /// | Bit(s) | Name              | Description                                                                                                        >
+    /// |--------|-------------------|-------------------------------------------------------------------------------------------------------------------->
+    /// | 7:0    | ABI_MINOR         | The minimum ABI minor version required for this guest to run.                                                      >
+    /// | 15:8   | ABI_MAJOR         | The minimum ABI major version required for this guest to run.                                                      >
+    /// | 16     | SMT               | 0: Host SMT usage is disallowed.<br>1: Host SMT usage is allowed.                                                  >
+    /// | 17     | -                 | Reserved. Must be one.                                                                                             >
+    /// | 18     | MIGRATE_MA        | 0: Association with a migration agent is disallowed.<br>1: Association with a migration agent is allowed           >
+    /// | 19     | DEBUG             | 0: Debugging is disallowed.<br>1: Debugging is allowed.                                                            >
+    /// | 20     | SINGLE_SOCKET     | 0: Guest can be activated on multiple sockets.<br>1: Guest can only be activated on one socket.                    >
+    /// | 21     | CXL_ALLOW         | 0: CXL cannot be populated with devices or memory.<br>1: CXL can be populated with devices or memory.              >
+    /// | 22     | MEM_AES_256_XTS   | 0: Allow either AES 128 XEX or AES 256 XTS for memory encryption.<br>1: Require AES 256 XTS for memory encryption. >
+    /// | 23     | RAPL_DIS          | 0: Allow Running Average Power Limit (RAPL).<br>1: RAPL must be disabled.                                          >
+    /// | 24     | CIPHERTEXT_HIDING | 0: Ciphertext hiding may be enabled or disabled.<br>1: Ciphertext hiding must be enabled.                          >
+    /// | 63:25  | -                 | Reserved. MBZ.                                                                                                     >
     ///
     #[derive(Default, Clone, Copy)]
     #[derive(Deserialize, Serialize)]

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -427,6 +427,14 @@ bitfield! {
     pub debug_allowed, _: 19, 19;
     /// SINGLE_SOCKET_REQUIRED field: Indicates the if a single socket is required.
     pub single_socket_required, _: 20, 20;
+    /// CXL_ALLOW field: (1) can populate CXL devices/memory, (0) cannot populate CXL devices/memory
+    pub cxl_allowed, _: 21, 21;
+    /// MEM_AES_256_XTS field: (1) require AES 256 XTS encryption, (0) allows either AES 128 XEX or AES 256 XTS encryption
+    pub mem_aes_256_xts, _: 22, 22;
+    /// RAPL_DIS field: (1) RAPL must be disabled, (0) allow RAPL
+    pub rapl_dis, _: 23, 23;
+    /// CIPHERTEXT_HIDING field: (1) ciphertext hiding must be enabled, (0) ciphertext hiding may be enabled/disabled
+    pub ciphertext_hiding, _: 24, 24;
 }
 
 impl Display for GuestPolicy {


### PR DESCRIPTION
## Description:
- adding guest policies for CXL_ALLOW, MEM_AES_256_XTS, RAPL_DIS, and CIPHERTEXT_HIDING fields.
- ensuring comments reflect the current documentation on what each of those fields does.

## Linked Issues
- [Issue 144](https://github.com/virtee/sev/issues/144)

## Testing Results
- `cargo test`
```
   Compiling futures-sink v0.3.28
   Compiling pin-project-lite v0.2.13
   Compiling scopeguard v1.2.0
   Compiling futures-io v0.3.28
   Compiling bitflags v1.3.2
   Compiling cfg-if v1.0.0
   Compiling libc v0.2.150
   Compiling futures-core v0.3.28
   Compiling slab v0.4.9
   Compiling futures-task v0.3.28
   Compiling smallvec v1.11.1
   Compiling memchr v2.6.4
   Compiling pin-utils v0.1.0
   Compiling option-ext v0.2.0
   Compiling lazy_static v1.4.0
   Compiling serde v1.0.192
   Compiling hashbrown v0.14.1
   Compiling once_cell v1.18.0
   Compiling log v0.4.20
   Compiling lock_api v0.4.10
   Compiling hex v0.4.3
   Compiling bitfield v0.13.2
   Compiling futures-channel v0.3.28
   Compiling iocuddle v0.1.1
   Compiling static_assertions v1.1.0
   Compiling byteorder v1.5.0
   Compiling codicon v3.0.0
   Compiling futures-util v0.3.28
   Compiling parking_lot_core v0.9.8
   Compiling dirs-sys v0.4.1
   Compiling vmm-sys-util v0.11.2
   Compiling dirs v5.0.1
   Compiling parking_lot v0.12.1
   Compiling dashmap v5.5.3
   Compiling kvm-bindings v0.6.0
   Compiling kvm-ioctls v0.15.0
   Compiling serde_bytes v0.11.12
   Compiling uuid v1.5.0
   Compiling bincode v1.3.3
   Compiling serde-big-array v0.5.1
   Compiling futures-executor v0.3.28
   Compiling futures v0.3.28
   Compiling serial_test v2.0.0
   Compiling sev v2.0.2 (/home/bfurner27/dev/open-source/sev)
    Finished test [unoptimized + debuginfo] target(s) in 13.13s
     Running unittests src/lib.rs (target/debug/deps/sev-01cc842688d58615)

running 12 tests
test firmware::linux::guest::types::test::snp_report_req::test_new ... ok
test firmware::linux::guest::types::test::snp_report_req::test_new_error - should panic ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_parse_table_regular ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_parse_table_offset_short - should panic ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_uapi_to_vec_bytes ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_array ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_ptr ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_slice ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec_mut_ref ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec_ref ... ok
test util::impl_const_id::tests::test_const_id_macro ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/api.rs (target/debug/deps/api-7e631f5560643a4b)

running 13 tests
test sev::get_identifier ... ignored
test sev::pdh_generate ... ignored
test sev::pek_csr ... ignored
test sev::pek_generate ... ignored
test sev::platform_reset ... ignored
test sev::platform_status ... ignored
test snp::get_ext_config_std ... ignored
test snp::get_identifier ... ignored
test snp::platform_status ... ignored
test snp::set_ext_config_certs_only ... ignored
test snp::set_ext_config_cfg_only ... ignored
test snp::set_ext_config_std ... ignored
test snp::set_ext_invalid_config_std ... ignored

test result: ok. 0 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/certs.rs (target/debug/deps/certs-dfc13bdb82653056)

running 24 tests
test naples::ark::decode ... ok
test naples::ark::encode ... ok
test naples::ask::decode ... ok
test naples::ask::encode ... ok
test naples::cek::decode ... ok
test naples::cek::encode ... ok
test naples::oca::decode ... ok
test naples::pdh::encode ... ok
test naples::oca::encode ... ok
test naples::pdh::decode ... ok
test naples::pek::decode ... ok
test rome::ask::decode ... ok
test rome::ark::decode ... ok
test rome::ask::encode ... ok
test rome::cek::decode ... ok
test naples::pek::encode ... ok
test rome::ark::encode ... ok
test rome::cek::encode ... ok
test rome::oca::decode ... ok
test rome::oca::encode ... ok
test rome::pdh::decode ... ok
test rome::pdh::encode ... ok
test rome::pek::encode ... ok
test rome::pek::decode ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/guest.rs (target/debug/deps/guest-5702e478152ee620)

running 3 tests
test get_derived_key ... ignored
test get_ext_report ... ignored
test get_report ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/launch.rs (target/debug/deps/launch-f2ff50d5a21eee1e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/measurement.rs (target/debug/deps/measurement-35356a2e4d9469f6)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/session.rs (target/debug/deps/session-039b2d081330207d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/snp_launch.rs (target/debug/deps/snp_launch-1c79163b7928bd22)

running 1 test
test snp ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests sev

running 10 tests
test src/firmware/guest/mod.rs - firmware::guest::Firmware::get_derived_key (line 204) ... ignored
test src/firmware/guest/mod.rs - firmware::guest::Firmware::get_report (line 75) ... ignored
test src/firmware/guest/mod.rs - firmware::guest::Firmware::open (line 61) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_get_ext_config (line 221) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_platform_status (line 179) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_reset_config (line 197) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_set_ext_config (line 255) ... ignored
test src/lib.rs - Generation (line 214) - compile ... ok
test src/error.rs - error::VmmError::from (line 49) ... ok
test src/error.rs - error::VmmError::from (line 72) ... ok

test result: ok. 3 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.55s
```
- `cargo test --features=openssl`
```
  Downloaded openssl-sys v0.9.93
  Downloaded openssl v0.10.57
  Downloaded 2 crates (329.7 KB) in 0.55s
   Compiling pkg-config v0.3.27
   Compiling vcpkg v0.2.15
   Compiling cc v1.0.83
   Compiling foreign-types-shared v0.1.1
   Compiling openssl v0.10.57
   Compiling bitflags v2.4.0
   Compiling sev v2.0.2 (/home/bfurner27/dev/open-source/sev)
   Compiling openssl-macros v0.1.1
   Compiling foreign-types v0.3.2
   Compiling openssl-sys v0.9.93
    Finished test [unoptimized + debuginfo] target(s) in 18.40s
     Running unittests src/lib.rs (target/debug/deps/sev-842039a715df7582)

running 22 tests
test firmware::linux::guest::types::test::snp_report_req::test_new ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_parse_table_offset_short - should panic ... ok
test firmware::linux::guest::types::test::snp_report_req::test_new_error - should panic ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_parse_table_regular ... ok
test firmware::linux::host::types::snp::test::cert_table_entry::test_uapi_to_vec_bytes ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_array ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_ptr ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_slice ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec_mut_ref ... ok
test firmware::linux::host::types::snp::test::raw_data::test_from_u8_vec_ref ... ok
test util::impl_const_id::tests::test_const_id_macro ... ok
test session::key::derive ... ok
test session::initialized::verify ... ok
test session::key::mac ... ok
test certs::snp::builtin::genoa::tests::ark_self_signed ... ok
test certs::snp::builtin::milan::tests::ark_self_signed ... ok
test certs::snp::ca::tests::milan_ca_chain_verifiable ... ok
test certs::snp::builtin::genoa::tests::ark_signs_ask ... ok
test certs::snp::builtin::milan::tests::ark_signs_ask ... ok
test certs::snp::ca::tests::genoa_ca_chain_verifiable ... ok
test session::initialized::session ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/api.rs (target/debug/deps/api-917721686015ac96)

running 15 tests
test sev::get_identifier ... ignored
test sev::pdh_cert_export ... ignored
test sev::pdh_generate ... ignored
test sev::pek_cert_import ... ignored
test sev::pek_csr ... ignored
test sev::pek_generate ... ignored
test sev::platform_reset ... ignored
test sev::platform_status ... ignored
test snp::get_ext_config_std ... ignored
test snp::get_identifier ... ignored
test snp::platform_status ... ignored
test snp::set_ext_config_certs_only ... ignored
test snp::set_ext_config_cfg_only ... ignored
test snp::set_ext_config_std ... ignored
test snp::set_ext_invalid_config_std ... ignored

test result: ok. 0 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/certs.rs (target/debug/deps/certs-f1ada92897ae3c3b)

running 43 tests
test naples::ark::decode ... ok
test naples::ark::encode ... ok
test naples::ask::decode ... ok
test naples::cek::decode ... ok
test naples::ask::encode ... ok
test naples::cek::encode ... ok
test naples::oca::decode ... ok
test naples::oca::encode ... ok
test naples::pdh::encode ... ok
test naples::pdh::decode ... ok
test naples::pek::encode ... ok
test naples::pek::decode ... ok
test rome::ark::decode ... ok
test rome::ark::encode ... ok
test rome::ask::decode ... ok
test rome::ask::encode ... ok
test rome::cek::decode ... ok
test rome::cek::encode ... ok
test rome::oca::decode ... ok
test rome::oca::encode ... ok
test rome::pdh::decode ... ok
test rome::ark::verify ... ok
test rome::pdh::encode ... ok
test rome::pek::decode ... ok
test rome::pek::encode ... ok
test naples::ask::verify ... ok
test sev::test_for_verify_false_positive ... ok
test naples::ark::verify ... ok
test rome::cek::verify ... ok
test naples::cek::verify ... ok
test naples::oca::verify ... ok
test rome::oca::verify ... ok
test rome::pdh::verify ... ok
test naples::pdh::verify ... ok
test rome::ask::verify ... ok
test snp::milan_chain ... ok
test rome::pek::verify ... ok
test naples::pek::verify ... ok
test snp::milan_chain_invalid ... ok
test snp::milan_report ... ok
test snp::milan_report_invalid ... ok
test rome::oca::create ... ok
test naples::oca::create ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

     Running tests/guest.rs (target/debug/deps/guest-9a1c419d04adefad)

running 3 tests
test get_derived_key ... ignored
test get_ext_report ... ignored
test get_report ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/launch.rs (target/debug/deps/launch-3f8961ebe5149415)

running 1 test
test sev ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/measurement.rs (target/debug/deps/measurement-021e14ecd5581271)

running 15 tests
test sev_tests::test_sev_with_ovmfx64_and_kernel_should_fail - should panic ... ok
test sev_tests::test_sev_with_ovmfx64_without_kernel ... ok
test sev_tests::test_seves_with_ovmfx64_and_kernel_should_fail - should panic ... ok
test snp_tests::test_snp_with_ovmfx64_without_kernel ... ok
test snp_tests::test_snp_with_multiple_vcpus ... ok
test snp_tests::test_snp_with_ovmfx64_and_kernel_should_fail - should panic ... ok
test snp_tests::test_snp_without_kernel ... ok
test snp_tests::test_snp_ovmf_hash_gen ... ok
test sev_tests::test_seves ... ok
test sev_tests::test_seves_with_multiple_vcpus ... ok
test sev_tests::test_sev_with_kernel_without_initrd_and_append ... ok
test sev_tests::test_sev ... ok
test snp_tests::test_snp_ovmf_hash_full ... ok
test snp_tests::test_snp_ec2 ... ok
test snp_tests::test_snp ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/session.rs (target/debug/deps/session-7fc47f3286d43a37)

running 2 tests
test initialized::create ... ok
test initialized::start ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/snp_launch.rs (target/debug/deps/snp_launch-3f7b497b1ba26164)

running 1 test
test snp ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests sev

running 10 tests
test src/firmware/guest/mod.rs - firmware::guest::Firmware::get_derived_key (line 204) ... ignored
test src/firmware/guest/mod.rs - firmware::guest::Firmware::get_report (line 75) ... ignored
test src/firmware/guest/mod.rs - firmware::guest::Firmware::open (line 61) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_get_ext_config (line 221) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_platform_status (line 179) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_reset_config (line 197) ... ignored
test src/firmware/host/mod.rs - firmware::host::Firmware::snp_set_ext_config (line 255) ... ignored
test src/lib.rs - Generation (line 214) - compile ... ok
test src/error.rs - error::VmmError::from (line 72) ... ok
test src/error.rs - error::VmmError::from (line 49) ... ok

test result: ok. 3 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.99s
```