### PR TITLE
Certs: Adding generic support.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,24 @@ use std::{
 
 use std::os::raw::c_int;
 
+#[cfg(feature = "openssl")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CertFormatError {
+    UnknownFormat,
+}
+
+#[cfg(feature = "openssl")]
+impl std::error::Error for CertFormatError {}
+
+#[cfg(feature = "openssl")]
+impl std::fmt::Display for CertFormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownFormat => write!(f, "Unknown Certificate Format Encountered."),
+        }
+    }
+}
+
 /// An error representingthe upper 32 bits of a SW_EXITINFO2 field set by the VMM.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VmmError {


### PR DESCRIPTION
Adding generic support to automatically identify which type of certificate the user provided and construct a Certificate from the identity discovered.

Also adds an explicit `openssl` feature flag instead of relying on the inferred flag.