### PR TITLE
Certificates: Adding Ord and PartialOrd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTee Project Developers",


### PR DESCRIPTION
Adding Ord and Partial Ord to:
- firmware::host::types::snp::CertType
- firmware::host::types::snp::CertTableEntry

This will allow for sorting of a `Vec<CertTableEntry>` which, when sorted, will place the order as such:

ARK < VCEK < VLEK < ASK < CRL < OTHER < Empty

Making ARK the first in a sorted vect, etc.