### PR TITLE
certs: Auto sort extended guest request certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "3.1.0"
+version = "3.1.1"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTee Project Developers",

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -185,13 +185,14 @@ impl Firmware {
             return Ok((report_response.report, None));
         }
 
-        let certificates: Vec<CertTableEntry>;
+        let mut certificates: Vec<CertTableEntry>;
 
         unsafe {
             let entries = (ext_report_request.certs_address as *mut HostFFI::types::CertTableEntry)
                 .as_mut()
                 .ok_or(CertError::EmptyCertBuffer)?;
             certificates = HostFFI::types::CertTableEntry::parse_table(entries)?;
+            certificates.sort();
         }
 
         // Return both the Attestation Report, as well as the Cert Table.


### PR DESCRIPTION
This adds missing functionality to automatically sort certifactes obtained by an extended guest request