### PR TITLE
Correct the links at the crate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 # sev
 
 The `sev` crate provides an implementation of the [AMD Secure Encrypted
-Virtualization (SEV)](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/55766_SEV-KM_API_Specification.pdf) APIs and the [SEV Secure Nested Paging
-Firmware (SNP)] (https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf) ABIs.
+Virtualization (SEV)][SEV] APIs and the [SEV Secure Nested Paging
+Firmware (SNP)][SNP] ABIs.
+
+[SEV]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/55766_SEV-KM_API_Specification.pdf
+[SNP]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf
 
 ### SEV APIs
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! The `sev` crate provides an implementation of the [AMD Secure Encrypted
-//! Virtualization (SEV)](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/55766_SEV-KM_API_Specification.pdf) APIs and the [SEV Secure Nested Paging
-//! Firmware (SNP)] (https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf) ABIs.
+//! Virtualization (SEV)][SEV] APIs and the [SEV Secure Nested Paging
+//! Firmware (SNP)][SNP] ABIs.
+//!
+//! [SEV]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/55766_SEV-KM_API_Specification.pdf
+//! [SNP]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf
 //!
 //! ## SEV APIs
 //!


### PR DESCRIPTION
Fixes this:

<img width="1067" alt="image" src="https://github.com/virtee/sev/assets/265507/f76d33a0-f9eb-40c6-97f4-ea4489de1aa8">
