### PR TITLE
Unify Duplicated GuestPolicy Definitions

### DIFF
--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -414,32 +414,32 @@ bitfield! {
     /// | 24     | CIPHERTEXT_HIDING | 0: Ciphertext hiding may be enabled or disabled.<br>1: Ciphertext hiding must be enabled.                          >
     /// | 63:25  | -                 | Reserved. MBZ.                                                                                                     >
     ///
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Clone, Copy,Eq, PartialEq)]
     #[derive(Deserialize, Serialize)]
     #[repr(C)]
     pub struct GuestPolicy(u64);
     impl Debug;
     /// ABI_MINOR field: Indicates the minor API version.
-    pub abi_minor, _: 7, 0;
+    pub abi_minor, set_abi_minor: 7, 0;
     /// ABI_MAJOR field: Indicates the minor API version.
-    pub abi_major, _: 15, 8;
+    pub abi_major, set_abi_major: 15, 8;
     /// SMT_ALLOWED field: Indicates the if SMT should be permitted.
-    pub smt_allowed, _: 16, 16;
+    pub smt_allowed, set_smt_allowed: 16, 16;
     /// MIGRATE_MA_ALLOWED field: Indicates the if migration is permitted with
     /// the migration agent.
-    pub migrate_ma_allowed, _: 18, 18;
+    pub migrate_ma_allowed, set_migrate_ma_allowed: 18, 18;
     /// DEBUG_ALLOWED field: Indicates the if debugging should is permitted.
-    pub debug_allowed, _: 19, 19;
+    pub debug_allowed, set_debug_allowed: 19, 19;
     /// SINGLE_SOCKET_REQUIRED field: Indicates the if a single socket is required.
-    pub single_socket_required, _: 20, 20;
+    pub single_socket_required, set_single_socket_required: 20, 20;
     /// CXL_ALLOW field: (1) can populate CXL devices/memory, (0) cannot populate CXL devices/memory
-    pub cxl_allowed, _: 21, 21;
+    pub cxl_allowed, set_cxl_allowed: 21, 21;
     /// MEM_AES_256_XTS field: (1) require AES 256 XTS encryption, (0) allows either AES 128 XEX or AES 256 XTS encryption
-    pub mem_aes_256_xts, _: 22, 22;
+    pub mem_aes_256_xts, set_mem_aes_256_xts: 22, 22;
     /// RAPL_DIS field: (1) RAPL must be disabled, (0) allow RAPL
-    pub rapl_dis, _: 23, 23;
+    pub rapl_dis, set_rapl_dis: 23, 23;
     /// CIPHERTEXT_HIDING field: (1) ciphertext hiding must be enabled, (0) ciphertext hiding may be enabled/disabled
-    pub ciphertext_hiding, _: 24, 24;
+    pub ciphertext_hiding, set_ciphertext_hiding: 24, 24;
 }
 
 impl Display for GuestPolicy {
@@ -462,6 +462,12 @@ impl Display for GuestPolicy {
             self.debug_allowed(),
             self.single_socket_required()
         )
+    }
+}
+
+impl From<GuestPolicy> for u64 {
+    fn from(value: GuestPolicy) -> Self {
+        value.0
     }
 }
 

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -25,6 +25,8 @@ const CODE: &[u8; 4096] = &[
 #[cfg_attr(not(has_sev), ignore)]
 #[test]
 fn snp() {
+    use sev::firmware::guest::GuestPolicy;
+
     let kvm_fd = Kvm::new().unwrap();
     let vm_fd = kvm_fd.create_vm().unwrap();
 
@@ -59,15 +61,9 @@ fn snp() {
     let sev = Firmware::open().unwrap();
     let launcher = Launcher::new(vm_fd, sev).unwrap();
 
-    let start = Start::new(
-        None,
-        Policy {
-            flags: PolicyFlags::SMT,
-            ..Default::default()
-        },
-        false,
-        [0; 16],
-    );
+    let mut policy = GuestPolicy(0);
+    policy.set_smt_allowed(1);
+    let start = Start::new(None, policy, false, [0; 16]);
 
     let mut launcher = launcher.start(start).unwrap();
 


### PR DESCRIPTION
Unifies the duplicated `GuestPolicy` definition, as discussed in https://github.com/virtee/sev/issues/165  .

I am not quite happy with the "ergonomics" of the bitflags! macro. If I am not overlooking something, it requires to instantiate a mutable variable and use the set_XXX functions to create an instance using the bit definitions. Crates like [modular_bitfield](https://docs.rs/modular-bitfield/0.11.2/modular_bitfield/) seem more ergonomic, but I don't have a good overview of the available crates for this problem space