### PR TITLE
vlek: Adding vlek ioctls

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -174,6 +174,9 @@ pub enum UserApiError {
     /// Uuid parsing errors.
     UuidError(uuid::Error),
 
+    /// VLEK Hashstick errors.
+    HashstickError(HashstickError),
+
     /// Invalid VMPL.
     VmplError,
 
@@ -188,6 +191,7 @@ impl error::Error for UserApiError {
             Self::FirmwareError(firmware_error) => Some(firmware_error),
             Self::UuidError(uuid_error) => Some(uuid_error),
             Self::VmmError(vmm_error) => Some(vmm_error),
+            Self::HashstickError(hashstick_error) => Some(hashstick_error),
             Self::VmplError => None,
             Self::Unknown => None,
         }
@@ -201,10 +205,17 @@ impl std::fmt::Display for UserApiError {
             Self::ApiError(error) => format!("Certificate Error Encountered: {error}"),
             Self::UuidError(error) => format!("UUID Error Encountered: {error}"),
             Self::VmmError(error) => format!("VMM Error Encountered: {error}"),
+            Self::HashstickError(error) => format!("VLEK Hashstick Error Encountered: {error}"),
             Self::VmplError => "Invalid VM Permission Level (VMPL)".to_string(),
             Self::Unknown => "Unknown Error Encountered!".to_string(),
         };
         write!(f, "{err_msg}")
+    }
+}
+
+impl std::convert::From<HashstickError> for UserApiError {
+    fn from(value: HashstickError) -> Self {
+        Self::HashstickError(value)
     }
 }
 
@@ -235,6 +246,42 @@ impl std::convert::From<std::io::Error> for UserApiError {
 impl std::convert::From<CertError> for UserApiError {
     fn from(cert_error: CertError) -> Self {
         Self::ApiError(cert_error)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// Errors which may be encountered when handling Version Loaded Endorsement Keys
+/// (VLEK) Hashsticks.
+pub enum HashstickError {
+    /// Hashstick length does not match what was specified in the buffer.
+    InvalidLength,
+
+    /// No hashstick was provided
+    EmptyHashstickBuffer,
+
+    /// Unknown Error.
+    UnknownError,
+}
+
+impl std::error::Error for HashstickError {}
+
+impl std::fmt::Display for HashstickError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HashstickError::InvalidLength => {
+                write!(
+                    f,
+                    "VLEK hashstick is an invalid length. Should be 432 bytes in size."
+                )
+            }
+            HashstickError::EmptyHashstickBuffer => write!(f, "Hashstick buffer is empty."),
+            HashstickError::UnknownError => {
+                write!(
+                    f,
+                    "Unknown error encountered when handling the VLEK Hashstick."
+                )
+            }
+        }
     }
 }
 

--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -237,6 +237,30 @@ impl Firmware {
 
         Ok(())
     }
+
+    #[cfg(feature = "snp")]
+    /// Insert a Version Loaded Endorsement Key Hashstick into the AMD Secure Processor.
+    ///
+    /// # Example:
+    /// ```ignore
+    /// # Read the VLEK Hashstick Bytes into your application.
+    /// # Our variable will be "hashstick_bytes"
+    ///
+    /// let mut firmware: Firmware = Firmware::open().unwrap();
+    ///
+    /// firmware.snp_vlek_load(hashstick_bytes.as_slice()).unwrap();
+    /// ```
+    pub fn snp_vlek_load(&mut self, hashstick_bytes: &[u8]) -> Result<(), UserApiError> {
+        use types::FFI::types::{SnpVlekLoad, WrappedVlekHashstick};
+
+        let parsed_bytes: WrappedVlekHashstick = hashstick_bytes.try_into()?;
+
+        let mut vlek_load: SnpVlekLoad = SnpVlekLoad::new(&parsed_bytes);
+
+        SNP_VLEK_LOAD.ioctl(&mut self.0, &mut Command::from_mut(&mut vlek_load))?;
+
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src/firmware/linux/host/ioctl.rs
+++ b/src/firmware/linux/host/ioctl.rs
@@ -32,6 +32,7 @@ impl_const_id! {
     SnpPlatformStatus = 0x9,
     SnpCommit = 0xA,
     SnpSetConfig = 0xB,
+    SnpVlekLoad = 0xC,
 }
 
 #[cfg(all(feature = "sev", not(feature = "snp")))]
@@ -56,6 +57,7 @@ impl_const_id! {
     SnpPlatformStatus = 0x9,
     SnpCommit = 0xA,
     SnpSetConfig = 0xB,
+    SnpVlekLoad = 0xC,
 }
 
 const SEV: Group = Group::new(b'S');
@@ -113,6 +115,10 @@ pub const SNP_COMMIT: Ioctl<WriteRead, &Command<SnpCommit>> = unsafe { SEV.write
 /// C IOCTL calls -> sev_ioctl_do_snp_set_config
 #[cfg(feature = "snp")]
 pub const SNP_SET_CONFIG: Ioctl<WriteRead, &Command<SnpSetConfig>> = unsafe { SEV.write_read(0) };
+
+#[cfg(feature = "snp")]
+/// Load a specified VLEK hashstick into the AMD Secure Processor to be used in place of VCEK.
+pub const SNP_VLEK_LOAD: Ioctl<WriteRead, &Command<SnpVlekLoad>> = unsafe { SEV.write_read(0) };
 
 /// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
 /// used to pass arguments to the SEV ioctl implementation.


### PR DESCRIPTION
Adding in ioctls for SNP_VLEK_LOAD to allow platform owners to load VLEK where appropriate.