### PR TITLE
certs: Adding additional functionality.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "3.2.0"
+version = "3.3.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",

--- a/src/certs/snp/cert.rs
+++ b/src/certs/snp/cert.rs
@@ -59,6 +59,25 @@ impl From<&Certificate> for X509 {
     }
 }
 
+impl From<&X509> for Certificate {
+    fn from(value: &X509) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl From<&[X509]> for Certificate {
+    /// Retrieves only the first value from the hash, ignoring all other values.
+    fn from(value: &[X509]) -> Self {
+        value[0].clone().into()
+    }
+}
+
+impl<'a: 'b, 'b> From<&'a Certificate> for &'b X509 {
+    fn from(value: &'a Certificate) -> Self {
+        &value.0
+    }
+}
+
 /// Verify if the public key of one Certificate signs another Certificate.
 impl Verifiable for (&Certificate, &Certificate) {
     type Output = ();


### PR DESCRIPTION
- Made X509 within Certificate pub (requires major version bump).
- Added in a bunch of additional support for translating between `Certificate`, `openssl::X509`, `ca::Chain`, and `Chain`