### PR TITLE
build: Fixing linting issue for build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,11 @@
 fn main() {
     use std::path::Path;
 
+    // Register custom cfg flags for `has_sev` and `has_sev_guest`.
+    println!("cargo:rustc-check-cfg=cfg(has_sev)");
+    println!("cargo:rustc-check-cfg=cfg(has_sev_guest)");
+
+    // If the device driver is found, set the cfg flag
     if cfg!(feature = "hw_tests") || Path::new("/dev/sev").exists() {
         println!("cargo:rustc-cfg=has_sev");
     }


### PR DESCRIPTION
Previously we were not registering the custom flags for rustc to check. Adding these two lines fixes a bunch of linting issues

EDIT: For Context see [rust-check-cfg](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg)