### PR TITLE
rand: Removing use of openssl rand for crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.3.0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bincode",
@@ -869,6 +878,7 @@ dependencies = [
  "libc",
  "openssl",
  "p384",
+ "rdrand",
  "rsa",
  "serde",
  "serde-big-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "3.3.0"
+version = "4.0.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",
@@ -38,6 +38,7 @@ doc = false
 
 [features]
 default = ["sev", "snp"]
+openssl = ["dep:openssl", "rdrand"]
 hw_tests = []
 dangerous_hw_tests = ["hw_tests"]
 sev = []
@@ -68,6 +69,7 @@ sha2 = { version = "0.10.8", optional = true }
 x509-cert = { version = "0.2.5", optional = true }
 byteorder = "1.4.3"
 base64 = "0.22.1"
+rdrand = { version = "^0.8", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 kvm-ioctls = ">=0.16"


### PR DESCRIPTION
According to the documentation, openssl's `rand_bytes(...)` function will be seeded with `/dev/urandom`, which is not sound for cryptographic application. We will be switching to using the `rdrand` crate which will utilize the X86_64 microcode call to `RDRAND`, instead. All X86_64 instructions are protected by the Guest Hypervisor Communication Block (GHCB), and may thus be presumed secure for cryptographic practices in the context of confidential compute.

Obviously this introduces a change to the API, requiring a new major release of the crate.

Resolves: #189