### PR TITLE
cleanup: Removing unnecessary .into() calls

### DIFF
--- a/src/certs/sev/ca/cert/mod.rs
+++ b/src/certs/sev/ca/cert/mod.rs
@@ -89,7 +89,7 @@ impl codicon::Decoder<()> for Certificate {
             1 => Certificate {
                 v1: v1::Certificate::decode(reader, params)?,
             },
-            _ => return Err(ErrorKind::InvalidData.into()),
+            _ => return Err(ErrorKind::InvalidData)?,
         })
     }
 }
@@ -100,7 +100,7 @@ impl codicon::Encoder<()> for Certificate {
     fn encode(&self, writer: impl Write, _: ()) -> Result<()> {
         match self.version() {
             1 => unsafe { self.v1.encode(writer, ()) },
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -112,7 +112,7 @@ impl codicon::Encoder<Body> for Certificate {
     fn encode(&self, writer: impl Write, _: Body) -> Result<()> {
         match self.version() {
             1 => unsafe { self.v1.encode(writer, Body) },
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -148,7 +148,7 @@ impl TryFrom<&Certificate> for Usage {
     fn try_from(value: &Certificate) -> Result<Self> {
         match value.version() {
             1 => Ok(unsafe { value.v1.preamble.data.usage }),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -168,7 +168,7 @@ impl TryFrom<&Certificate> for PublicKey<Usage> {
     fn try_from(value: &Certificate) -> Result<Self> {
         match value.version() {
             1 => unsafe { value.v1.try_into() },
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }

--- a/src/certs/sev/ca/cert/v1.rs
+++ b/src/certs/sev/ca/cert/v1.rs
@@ -54,13 +54,13 @@ pub struct Preamble {
 impl Preamble {
     fn size(&self) -> Result<Size> {
         if self.data.psize != self.data.msize {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         match u32::from_le(self.data.msize) {
             2048 => Ok(Size::Small),
             4096 => Ok(Size::Large),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }

--- a/src/certs/sev/ca/chain.rs
+++ b/src/certs/sev/ca/chain.rs
@@ -23,12 +23,12 @@ impl codicon::Decoder<()> for Chain {
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
         let ask = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&ask)? != Usage::ASK {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let ark = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&ark)? != Usage::ARK {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         Ok(Self { ask, ark })

--- a/src/certs/sev/crypto.rs
+++ b/src/certs/sev/crypto.rs
@@ -27,7 +27,7 @@ macro_rules! prv_decoder {
                     let prv = pkey::PKey::private_key_from_der(&buf)?;
                     let key = PublicKey::try_from(params)?;
                     if !prv.public_eq(&key.key) {
-                        return Err(ErrorKind::InvalidData.into());
+                        return Err(ErrorKind::InvalidData)?;
                     }
 
                     Ok(PrivateKey {
@@ -108,7 +108,7 @@ where
         let hash = sig.hash == self.hash;
         let id = sig.id.is_none() || sig.id == self.id;
         if !usage || !kind || !hash || !id {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let mut ver = sign::Verifier::new(sig.hash, &self.key)?;
@@ -125,7 +125,7 @@ where
             if ok {
                 Ok(())
             } else {
-                Err(ErrorKind::NotFound.into())
+                Err(ErrorKind::NotFound)?
             }
         })?
     }

--- a/src/certs/sev/sev/cert/mod.rs
+++ b/src/certs/sev/sev/cert/mod.rs
@@ -80,7 +80,7 @@ impl codicon::Decoder<()> for Certificate {
             1 => Certificate {
                 v1: v1::Certificate::decode(reader, params)?,
             },
-            _ => return Err(ErrorKind::InvalidData.into()),
+            _ => return Err(ErrorKind::InvalidData)?,
         })
     }
 }
@@ -91,7 +91,7 @@ impl codicon::Encoder<()> for Certificate {
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {
         match self.version() {
             1 => unsafe { writer.save(&self.v1) },
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -103,7 +103,7 @@ impl codicon::Encoder<Body> for Certificate {
     fn encode(&self, mut writer: impl Write, _: Body) -> Result<()> {
         match self.version() {
             1 => unsafe { writer.save(&self.v1.body) },
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -143,7 +143,7 @@ impl TryFrom<&Certificate> for [Option<Signature>; 2] {
                 unsafe { &value.v1.sigs[0] }.try_into()?,
                 unsafe { &value.v1.sigs[1] }.try_into()?,
             ]),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -154,7 +154,7 @@ impl TryFrom<&Certificate> for Usage {
     fn try_from(value: &Certificate) -> Result<Self> {
         match value.version() {
             1 => Ok(unsafe { value.v1.body.data.key.usage }),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -176,7 +176,7 @@ impl TryFrom<&Certificate> for PublicKey<Usage> {
             1 => PublicKey::try_from(unsafe {
                 &std::ptr::addr_of!(value.v1.body.data.key).read_unaligned()
             }),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -195,7 +195,7 @@ impl Verifiable for (&Certificate, &Certificate) {
             }
         }
 
-        Err(ErrorKind::InvalidInput.into())
+        Err(ErrorKind::InvalidInput)?
     }
 }
 
@@ -213,7 +213,7 @@ impl Verifiable for (&ca::Certificate, &Certificate) {
             }
         }
 
-        Err(ErrorKind::InvalidInput.into())
+        Err(ErrorKind::InvalidInput)?
     }
 }
 
@@ -224,7 +224,7 @@ impl Signer<Certificate> for PrivateKey<Usage> {
     fn sign(&self, target: &mut Certificate) -> Result<()> {
         match target.version() {
             1 => self.sign(unsafe { &mut target.v1 }),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }

--- a/src/certs/sev/sev/cert/v1/algo.rs
+++ b/src/certs/sev/sev/cert/v1/algo.rs
@@ -33,7 +33,7 @@ impl TryFrom<Algorithm> for pkey::Id {
             Algorithm::RSA_SHA256 | Algorithm::RSA_SHA384 => pkey::Id::RSA,
             Algorithm::ECDSA_SHA256 | Algorithm::ECDSA_SHA384 => pkey::Id::EC,
             Algorithm::ECDH_SHA256 | Algorithm::ECDH_SHA384 => pkey::Id::EC,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         })
     }
 }
@@ -52,7 +52,7 @@ impl TryFrom<Algorithm> for hash::MessageDigest {
                 Ok(hash::MessageDigest::sha384())
             }
 
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }

--- a/src/certs/sev/sev/cert/v1/body/key/ecc/group.rs
+++ b/src/certs/sev/sev/cert/v1/body/key/ecc/group.rs
@@ -16,7 +16,7 @@ impl Group {
         Ok(match self {
             Group::P256 => 32,
             Group::P384 => 48,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         })
     }
 }
@@ -29,7 +29,7 @@ impl TryFrom<Group> for nid::Nid {
         Ok(match value {
             Group::P256 => nid::Nid::X9_62_PRIME256V1,
             Group::P384 => nid::Nid::SECP384R1,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         })
     }
 }
@@ -42,7 +42,7 @@ impl TryFrom<nid::Nid> for Group {
         Ok(match value {
             nid::Nid::X9_62_PRIME256V1 => Group::P256,
             nid::Nid::SECP384R1 => Group::P384,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         })
     }
 }

--- a/src/certs/sev/sev/cert/v1/body/key/mod.rs
+++ b/src/certs/sev/sev/cert/v1/body/key/mod.rs
@@ -64,7 +64,7 @@ impl TryFrom<&PubKey> for pkey::PKey<pkey::Public> {
         match v.algo.try_into()? {
             pkey::Id::RSA => Ok(unsafe { &v.key.rsa }.try_into()?),
             pkey::Id::EC => Ok(unsafe { &v.key.ecc }.try_into()?),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }
@@ -93,7 +93,7 @@ impl PubKey {
             Usage::PEK => Algorithm::ECDSA_SHA256,
             Usage::CEK => Algorithm::ECDSA_SHA256,
             Usage::PDH => Algorithm::ECDH_SHA256,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         };
 
         let (key, prv) = ecc::PubKey::generate(ecc::group::Group::P384)?;

--- a/src/certs/sev/sev/cert/v1/body/key/rsa.rs
+++ b/src/certs/sev/sev/cert/v1/body/key/rsa.rs
@@ -18,7 +18,7 @@ impl PubKey {
         match u32::from_le(self.modulus_size) {
             2048 => Ok(256),
             4096 => Ok(512),
-            _ => Err(ErrorKind::InvalidInput.into()),
+            _ => Err(ErrorKind::InvalidInput)?,
         }
     }
 }

--- a/src/certs/sev/sev/cert/v1/mod.rs
+++ b/src/certs/sev/sev/cert/v1/mod.rs
@@ -53,7 +53,7 @@ impl Signer<Certificate> for PrivateKey<Usage> {
         } else if target.sigs[1].is_empty() {
             &mut target.sigs[1]
         } else {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         };
 
         let mut sig = sign::Signer::new(self.hash, &self.key)?;

--- a/src/certs/sev/sev/cert/v1/sig/mod.rs
+++ b/src/certs/sev/sev/cert/v1/sig/mod.rs
@@ -83,7 +83,7 @@ impl TryFrom<crate::certs::sev::Signature> for Signature {
 
     fn try_from(value: crate::certs::sev::Signature) -> Result<Self> {
         if value.id.is_some() {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let (sig, algo) = match value.kind {
@@ -93,7 +93,7 @@ impl TryFrom<crate::certs::sev::Signature> for Signature {
                 match value.hash.type_() {
                     nid::Nid::SHA256 => (sig, Algorithm::RSA_SHA256),
                     nid::Nid::SHA384 => (sig, Algorithm::RSA_SHA384),
-                    _ => return Err(ErrorKind::InvalidInput.into()),
+                    _ => return Err(ErrorKind::InvalidInput)?,
                 }
             }
 
@@ -103,11 +103,11 @@ impl TryFrom<crate::certs::sev::Signature> for Signature {
                 match value.hash.type_() {
                     nid::Nid::SHA256 => (sig, Algorithm::ECDSA_SHA256),
                     nid::Nid::SHA384 => (sig, Algorithm::ECDSA_SHA384),
-                    _ => return Err(ErrorKind::InvalidInput.into()),
+                    _ => return Err(ErrorKind::InvalidInput)?,
                 }
             }
 
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         };
 
         Ok(Signature {
@@ -133,7 +133,7 @@ impl TryFrom<&Signature> for Option<crate::certs::sev::Signature> {
         let sig = match kind {
             pkey::Id::RSA => Vec::try_from(unsafe { &value.sig.rsa })?,
             pkey::Id::EC => Vec::try_from(unsafe { &value.sig.ecdsa })?,
-            _ => return Err(ErrorKind::InvalidInput.into()),
+            _ => return Err(ErrorKind::InvalidInput)?,
         };
 
         Ok(Some(crate::certs::sev::Signature {

--- a/src/certs/sev/sev/chain.rs
+++ b/src/certs/sev/sev/chain.rs
@@ -29,22 +29,22 @@ impl codicon::Decoder<()> for Chain {
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
         let pdh = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&pdh)? != Usage::PDH {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let pek = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&pek)? != Usage::PEK {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let oca = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&oca)? != Usage::OCA {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         let cek = Certificate::decode(&mut reader, ())?;
         if Usage::try_from(&cek)? != Usage::CEK {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         Ok(Self { pdh, pek, oca, cek })

--- a/src/firmware/guest/mod.rs
+++ b/src/firmware/guest/mod.rs
@@ -40,7 +40,7 @@ use std::fs::{File, OpenOptions};
 //
 //         if lower != 0 {
 //             match lower.into() {
-//                 Indeterminate::Known(error) => return Err(error.into()),
+//                 Indeterminate::Known(error) => return Err(error)?,
 //                 Indeterminate::Unknown => return Err(UserApiError::Unknown),
 //             }
 //         }
@@ -149,10 +149,8 @@ impl Firmware {
         if let Err(ioctl_error) = SNP_GET_EXT_REPORT.ioctl(&mut self.0, &mut guest_request) {
             match guest_request.fw_err.into() {
                 VmmError::InvalidCertificatePageLength => (),
-                VmmError::RateLimitRetryRequest => {
-                    return Err(VmmError::RateLimitRetryRequest.into())
-                }
-                _ => return Err(ioctl_error.into()),
+                VmmError::RateLimitRetryRequest => return Err(VmmError::RateLimitRetryRequest)?,
+                _ => return Err(ioctl_error)?,
             }
 
             // Eventually the code below will be moved back into this scope.

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -223,7 +223,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<Finished, U, V> {
             if let Indeterminate::Known(InvalidLen) = err {
                 len = first.len;
             } else {
-                return Err(err.into());
+                return Err(err)?;
             }
         }
 

--- a/src/measurement/gctx.rs
+++ b/src/measurement/gctx.rs
@@ -81,7 +81,10 @@ impl Gctx<Updating> {
         page_info.extend_from_slice(&gpa.to_le_bytes());
 
         if page_info.len() != (page_info_len as usize) {
-            return Err(GCTXError::InvalidPageSize(page_info.len(), page_info_len as usize).into());
+            return Err(GCTXError::InvalidPageSize(
+                page_info.len(),
+                page_info_len as usize,
+            ))?;
         }
         self.ld = sha384(&page_info).as_slice().try_into()?;
 
@@ -114,7 +117,7 @@ impl Gctx<Updating> {
                     }
                     Ok(())
                 } else {
-                    Err(GCTXError::MissingData.into())
+                    Err(GCTXError::MissingData)?
                 }
             }
 
@@ -124,7 +127,7 @@ impl Gctx<Updating> {
                     self.update(page_type as u8, VMSA_GPA, sha384(data).as_slice())?;
                     Ok(())
                 } else {
-                    Err(GCTXError::MissingData.into())
+                    Err(GCTXError::MissingData)?
                 }
             }
 
@@ -138,7 +141,7 @@ impl Gctx<Updating> {
                     }
                     Ok(())
                 } else {
-                    Err(GCTXError::MissingBlockSize.into())
+                    Err(GCTXError::MissingBlockSize)?
                 }
             }
 

--- a/src/measurement/ovmf.rs
+++ b/src/measurement/ovmf.rs
@@ -274,7 +274,7 @@ impl OVMF {
         let expected_footer_guid = guid_le_to_slice(OVMF_TABLE_FOOTER_GUID.to_string().as_str())?;
 
         if !footer.guid.eq(&expected_footer_guid) {
-            return Err(OVMFError::MismatchingGUID.into());
+            return Err(OVMFError::MismatchingGUID)?;
         }
 
         if (footer.size as usize) < ENTRY_HEADER_SIZE {
@@ -282,8 +282,7 @@ impl OVMF {
                 "OVMF Table Footer".to_string(),
                 footer.size as usize,
                 ENTRY_HEADER_SIZE,
-            )
-            .into());
+            ))?;
         }
 
         let table_size = footer.size as usize - ENTRY_HEADER_SIZE;
@@ -299,8 +298,7 @@ impl OVMF {
                     "OVMF Table Entry".to_string(),
                     entry.size as usize,
                     ENTRY_HEADER_SIZE,
-                )
-                .into());
+                ))?;
             }
             let entry_guid = Uuid::from_slice_le(&entry.guid)?;
 
@@ -335,9 +333,9 @@ impl OVMF {
             }
 
             None => {
-                return Err(
-                    OVMFError::EntryMissingInTable("OVMF_SEV_METADATA_GUID".to_string()).into(),
-                );
+                return Err(OVMFError::EntryMissingInTable(
+                    "OVMF_SEV_METADATA_GUID".to_string(),
+                ))?;
             }
         }
 

--- a/src/measurement/sev_hashes.rs
+++ b/src/measurement/sev_hashes.rs
@@ -198,7 +198,7 @@ impl SevHashes {
     /// Construct an SEV Hash page using hash table.
     pub fn construct_page(&self, offset: usize) -> Result<Vec<u8>, MeasurementError> {
         if offset >= 4096 {
-            return Err(SevHashError::InvalidOffset(offset, 4096).into());
+            return Err(SevHashError::InvalidOffset(offset, 4096))?;
         }
 
         let hashes_table = self.construct_table()?;
@@ -207,7 +207,7 @@ impl SevHashes {
         page.extend_from_slice(&hashes_table[..]);
         page.resize(4096, 0);
         if page.len() != 4096 {
-            return Err(SevHashError::InvalidSize(page.len(), 4096).into());
+            return Err(SevHashError::InvalidSize(page.len(), 4096))?;
         }
         Ok(page)
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -171,7 +171,7 @@ impl Session<Initialized> {
         sig.update(&msr.mnonce)?;
 
         if sig.sign_to_vec()? != msr.measure {
-            return Err(ErrorKind::InvalidInput.into());
+            return Err(ErrorKind::InvalidInput)?;
         }
 
         Ok(Session {


### PR DESCRIPTION
Recently learned the more idomatic solution is to use the question mark operator instead of using .into() when casting error types.