### PR TITLE
Cargo.toml: Specify rdrand as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ doc = false
 
 [features]
 default = ["sev", "snp"]
-openssl = ["dep:openssl", "rdrand"]
+openssl = ["dep:openssl", "dep:rdrand"]
 hw_tests = []
 dangerous_hw_tests = ["hw_tests"]
 sev = []


### PR DESCRIPTION
Without the `dep:_` prefix, packagers can mistake this for being a feature, rather than the enablement of an optional dependency.