### PR TITLE
Adding deprecation flags for SEV components and bumping to 5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "5.0.0"
+version = "5.1.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",

--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Legacy SEV certificates.
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 pub mod sev;
 

--- a/src/certs/sev/builtin/mod.rs
+++ b/src/certs/sev/builtin/mod.rs
@@ -4,9 +4,24 @@
 //!
 //! These are primarily offered as a convenience measure to avoid making
 //! HTTP requests to AMD's servers.
-
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod genoa;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod milan;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod naples;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod rome;
 pub mod turin;

--- a/src/certs/sev/ca/cert/mod.rs
+++ b/src/certs/sev/ca/cert/mod.rs
@@ -10,7 +10,6 @@ use std::mem::size_of;
 
 use serde::{de, ser};
 use serde_bytes::{ByteBuf, Bytes};
-
 /// An OCA certificate.
 #[derive(Clone, Copy)]
 #[repr(C)]

--- a/src/certs/sev/ca/mod.rs
+++ b/src/certs/sev/ca/mod.rs
@@ -2,7 +2,15 @@
 
 //! For operating on OCA certificates.
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 mod cert;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 mod chain;
 
 pub use cert::Certificate;

--- a/src/certs/sev/mod.rs
+++ b/src/certs/sev/mod.rs
@@ -1,19 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Everything needed for working with AMD SEV certificate chains.
-
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod builtin;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod ca;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 mod chain;
-
-#[allow(clippy::module_inception)]
-pub mod sev;
-
-#[cfg(feature = "openssl")]
-mod util;
-
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "openssl")]
 mod crypto;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
+#[allow(clippy::module_inception)]
+pub mod sev;
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
+#[cfg(feature = "openssl")]
+mod util;
 
 pub use chain::Chain;
 

--- a/src/firmware/linux/host/types/mod.rs
+++ b/src/firmware/linux/host/types/mod.rs
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 mod sev;
 
 #[cfg(feature = "snp")]
 mod snp;
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 pub use self::sev::*;
 
@@ -48,6 +56,10 @@ impl<'a> GetId<'a> {
 /// Reset the platform's persistent state.
 ///
 /// (Chapter 5.5)
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 #[cfg(target_os = "linux")]
 pub struct PlatformReset;

--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -3,6 +3,10 @@
 //! Operations and types for launching on Linux
 pub(crate) mod ioctl;
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 pub(crate) mod sev;
 

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -10,6 +10,10 @@
 #[cfg(any(feature = "sev", feature = "snp"))]
 mod linux;
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(feature = "sev")]
 pub mod sev;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,19 @@ pub mod launch;
     target_os = "linux"
 ))]
 pub mod measurement;
+
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(all(target_os = "linux", feature = "openssl", feature = "sev"))]
 pub mod session;
 mod util;
+
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod vmsa;
 
 /// Error module.
@@ -238,10 +248,18 @@ impl codicon::Encoder<()> for Build {
 #[derive(Copy, Clone)]
 pub enum Generation {
     /// First generation EPYC (SEV).
+    #[deprecated(
+        since = "5.0.0",
+        note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+    )]
     #[cfg(feature = "sev")]
     Naples,
 
     /// Second generation EPYC (SEV, SEV-ES).
+    #[deprecated(
+        since = "5.0.0",
+        note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+    )]
     #[cfg(feature = "sev")]
     Rome,
 

--- a/src/measurement/mod.rs
+++ b/src/measurement/mod.rs
@@ -21,6 +21,10 @@ pub mod vcpu_types;
 #[cfg(all(feature = "snp", feature = "openssl"))]
 pub mod snp;
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[cfg(all(feature = "sev", feature = "openssl"))]
 pub mod sev;
 

--- a/src/measurement/sev.rs
+++ b/src/measurement/sev.rs
@@ -80,6 +80,10 @@ pub fn seves_calc_launch_digest(
     Ok(launch_hash.finish())
 }
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 /// Arguments required to calculate the SEV measurement
 pub struct SevMeasurementArgs<'a> {
     /// Path to OVMF file
@@ -92,6 +96,10 @@ pub struct SevMeasurementArgs<'a> {
     pub append: Option<&'a str>,
 }
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 /// Calculate an SEV launch digest
 pub fn sev_calc_launch_digest(
     sev_measurement: SevMeasurementArgs,

--- a/src/measurement/vmsa.rs
+++ b/src/measurement/vmsa.rs
@@ -13,6 +13,10 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SevMode {
     /// SEV
+    #[deprecated(
+        since = "5.0.0",
+        note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+    )]
     Sev,
     /// SEV-ES
     SevEs,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -3,6 +3,10 @@
 //! Utilities for creating a secure channel and facilitating the
 //! attestation process between the tenant and the AMD SP.
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 mod key;
 
 use crate::error::SessionError;
@@ -28,6 +32,10 @@ pub struct Verified(launch::sev::Measurement);
 /// Describes a secure channel with the AMD SP.
 ///
 /// This is required for facilitating an SEV launch and attestation.
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub struct Session<T> {
     policy: launch::sev::Policy,
 
@@ -119,6 +127,10 @@ impl Session<Initialized> {
 
     /// Like the above start function, yet takes PDH as input instead of deriving it from a
     /// certificate chain.
+    #[deprecated(
+        since = "5.0.0",
+        note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+    )]
     pub fn start_pdh(
         &self,
         pdh: certs::sev::sev::Certificate,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,7 +2,12 @@
 
 //! Helpful primitives for developing the crate.
 
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 pub mod cached_chain;
+
 mod impl_const_id;
 
 use std::{

--- a/src/vmsa/mod.rs
+++ b/src/vmsa/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Types and abstractions regarding Virtual Machine Save Areas (VMSAs).
+//! Types and abstractions regarding Legacy SEV Virtual Machine Save Areas (VMSAs).
 
 #![allow(dead_code)]
 
@@ -44,6 +44,10 @@ const ATTR_W_MASK: u16 = 1 << ATTR_W_SHIFT;
 /// Virtual Machine Control Block
 /// The layout of a VMCB struct is documented in Table B-1 of the
 /// AMD64 Architecture Programmer’s Manual, Volume 2: System Programming
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[repr(C, packed)]
 #[derive(Default, Serialize, Deserialize, Clone, Copy)]
 pub struct VmcbSegment {
@@ -65,6 +69,10 @@ pub struct VmcbSegment {
 /// Virtual Machine Save Area
 /// The layout of a VMCB struct is documented in Table B-4 of the
 /// AMD64 Architecture Programmer’s Manual, Volume 2: System Programming
+#[deprecated(
+    since = "5.0.0",
+    note = "Legacy SEV features will no longer be included/supported in library versions past 5"
+)]
 #[repr(C, packed)]
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct Vmsa {


### PR DESCRIPTION
As discussed, adding deprecation flags for SEV components, so that it can be removed in the next 6.0 release. Bumping to 5.1 so that people can still use 5.0.0 without compilation warnings if they are using SEV.