### PR TITLE
Fix legacy attestation report validation

### DIFF
--- a/src/certs/sev/sev/cert/v1/sig/ecdsa.rs
+++ b/src/certs/sev/sev/cert/v1/sig/ecdsa.rs
@@ -75,6 +75,19 @@ impl TryFrom<&[u8]> for Signature {
 }
 
 #[cfg(feature = "openssl")]
+impl TryFrom<&Array<u8, 144>> for ecdsa::EcdsaSig {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(value: &Array<u8, 144>) -> Result<Self> {
+        let arr: &[u8] = value.as_ref();
+        let r = bn::BigNum::from_le(&arr[..SIG_PIECE_SIZE])?;
+        let s = bn::BigNum::from_le(&arr[SIG_PIECE_SIZE..])?;
+        Ok(ecdsa::EcdsaSig::from_private_components(r, s)?)
+    }
+}
+
+#[cfg(feature = "openssl")]
 impl TryFrom<&Signature> for ecdsa::EcdsaSig {
     type Error = Error;
 


### PR DESCRIPTION
Hi folks,

For a couple of weeks, I've been investigating AMD SEV technology and experimenting with the `sev/sevctl` tool. I noticed that legacy report validation was only drafted (rewritten from the deprecated `sev-tool`) but actually does not work as expected. I've fixed that and tried to mimic the spirit of the `sevctl` tool as much as possible. This is my first contribution in Rust, so your feedback is highly appreciated.

What has been done in this PR:

* Corrected signature verification to use the SHA256 digest instead of raw data.
* Fixed signature size in `LegacyAttestationReport` by defining it as an `Array<u8, 144>` instead of an `EcdsaSignature` structure, which is 512 bytes.
* Fixed digest size in `LegacyAttestationReport`, ensuring `launch_digest` uses `DIGEST_SIZE` instead of `POLICY_SIZE`.

There should be another PR for `sevctl` itself coming soon, I'll provide a link to that PR once I push it.
Update: the `sevctl` part https://github.com/virtee/sevctl/pull/205
