### PR TITLE
idblocks: support a few other PEM formats

### DIFF
--- a/src/measurement/idblock.rs
+++ b/src/measurement/idblock.rs
@@ -62,13 +62,19 @@ enum KeyFormat {
     Der,
 }
 
-/// Identifies the format of a key based upon the first twenty-seven
-/// bytes of a byte stream. A non-PEM format assumes DER format.
+const PEM_PREFIXES: &[&[u8]] = &[
+    b"-----BEGIN PRIVATE KEY-----",           // PKCS8
+    b"-----BEGIN EC PRIVATE KEY-----",        // legacy EC
+    b"-----BEGIN ENCRYPTED PRIVATE KEY-----", // encrypted PKCS8
+];
+
+/// Identifies the format of a key based on the first line specified
+/// for the PEM. A non-PEM format assumes a DER format.
 fn identify_priv_key_format(bytes: &[u8]) -> KeyFormat {
-    const PEM_START: &[u8] = b"-----BEGIN PRIVATE KEY-----";
-    match &bytes[0..27] {
-        PEM_START => KeyFormat::Pem,
-        _ => KeyFormat::Der,
+    if PEM_PREFIXES.iter().any(|prefix| bytes.starts_with(prefix)) {
+        KeyFormat::Pem
+    } else {
+        KeyFormat::Der
     }
 }
 ///Read a key file and return a private EcKey.


### PR DESCRIPTION
It turns out that OpenSSL generates several types of PEM formats for private keys. The 'BEGIN PRIVATE KEY' is the PKCS8 format, but previously there was the EC 'legacy', which can still be used and generated successfully by OpenSSL. Among these, there are also encrypted PEM keys, which start with the 'BEGIN ENCRYPTED PRIVATE KEY' line and can also be used.

This patch extends support for PEM formats by adding two more: EC legacy ("BEGIN EC PRIVATE KEY") and PKCS8 encrypted ("BEGIN ENCRYPTED PRIVATE KEY").

Why bother? The following commands are all valid and generate three PEM keys:

```bash
openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:secp384r1 -out id-block-key.pem
```

```bash
openssl ecparam -name secp384r1 -genkey -noout -out id-block-key.pem
```

```bash
openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:secp384r1 -aes256 -out id-block-key.pem
```

but only the first one is supported by the `sev` library. This commit fixes the issue without any cost.