### PR TITLE
Firmware: Fix attestation report save to file for report versions >=3 on preTurin

### DIFF
--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -451,7 +451,7 @@ impl AttestationReport {
         // Determine the variant based on version and CPUID step
         let variant = if self.version == 2 {
             ReportVariant::V2
-        } else if self.version == 3 && (self.cpuid_fam_id.unwrap_or(0) < 0x1A) {
+        } else if self.version >= 3 && (self.cpuid_fam_id.unwrap_or(0) < 0x1A) {
             ReportVariant::V3PreTurin
         } else {
             ReportVariant::V3Turin


### PR DESCRIPTION
Generating a report with `snpguest` tooling on a VM running on GCP with report version `4` and firmware version `1.55.31` on a Milan CPU is getting saved as Turin report. Therefore a malformed report is getting saved and verification is failing.

As I have not found any public information about version `4` of the report structure and the verification of the report is successful with `snpguest` tooling including this fix, I assume that no major changes have occured to the report structure.

References:
https://github.com/google/go-sev-guest/pull/158/files Changes to googles SEV go library for report version `4` and firmware `1.55.31`.