### PR TITLE
Bumping version to 6.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "6.1.0"
+version = "6.2.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",


### PR DESCRIPTION
Want to bump to 6.2.0 to have the last 2 PRs, since they both include some bug fixes.