### PR TITLE
Fixing writing TCB bug and bumping to 6.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "6.2.0"
+version = "6.2.1"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -458,7 +458,6 @@ impl AttestationReport {
             ReportVariant::V2 => {
                 // V2 doesn't have CPUID fields
                 handle.skip_bytes::<24>()?.write_bytes(self.chip_id)?;
-                handle.write_bytes(self.committed_tcb.to_legacy_bytes())?;
             }
             _ => {
                 // Write CPUID fields for V3 and V4
@@ -466,10 +465,11 @@ impl AttestationReport {
                 handle.write_bytes(self.cpuid_mod_id.unwrap_or(0))?;
                 handle.write_bytes(self.cpuid_step.unwrap_or(0))?;
                 handle.skip_bytes::<21>()?.write_bytes(self.chip_id)?;
-                handle.write_bytes(self.committed_tcb.to_turin_bytes())?;
             }
         }
 
+        // Write committed TCB based on variant
+        write_tcb(&mut handle, &variant, &self.committed_tcb, turin_like)?;
         handle.write_bytes(self.current)?;
         handle.skip_bytes::<1>()?.write_bytes(self.committed)?;
 


### PR DESCRIPTION
An overlook on the last PR. Commited TCBs are being written wrong for v3 Pre-turins. This fix takes care of that issue. Bump to a minor bug fix so we can release fix.