### PR TITLE
Updating Library to Match Version 1.58 of the SNP Spec

### DIFF
--- a/src/firmware/host/types/snp.rs
+++ b/src/firmware/host/types/snp.rs
@@ -586,6 +586,8 @@ bitfield! {
     pub ciphertext_hiding_dram_cap, _: 5;
     /// Indicates ciphertext hiding is enabled for the DRAM.
     pub ciphertext_hiding_dram_en, _: 6;
+    /// Indicates TIO is enbaled. Present if SEV-TIO feature bit is set.
+    pub is_tio_en, _: 7;
 }
 
 impl Default for PlatformPolicy {
@@ -622,7 +624,8 @@ impl Display for PlatformPolicy {
     Feature Info Enabled {}
     RAPL Disabled: {}
     Ciphertext Capable: {}
-    Ciphertext enabled: {}"#,
+    Ciphertext enabled: {}
+    SEV-TIO enabled: {}"#,
             self.0,
             self.mask_chip_id(),
             self.mask_chip_key(),
@@ -631,6 +634,7 @@ impl Display for PlatformPolicy {
             self.rapl_dis(),
             self.ciphertext_hiding_dram_cap(),
             self.ciphertext_hiding_dram_en(),
+            self.is_tio_en()
         )
     }
 }

--- a/src/firmware/linux/guest/types.rs
+++ b/src/firmware/linux/guest/types.rs
@@ -33,6 +33,11 @@ pub struct DerivedKeyReq {
     /// The TCB version to mix into the derived key. Must not
     /// exceed CommittedTcb.
     pub tcb_version: u64,
+
+    /// The mitigation vector value to mix into the derived key.
+    /// Specific bit settings corresponding to mitigations required for Guest operation.
+    /// Introduced in FW 1.58, so if unset, it will default to 0.
+    pub launch_mit_vector: u64,
 }
 
 impl From<DerivedKey> for DerivedKeyReq {
@@ -44,6 +49,7 @@ impl From<DerivedKey> for DerivedKeyReq {
             vmpl: value.vmpl,
             guest_svn: value.guest_svn,
             tcb_version: value.tcb_version,
+            launch_mit_vector: value.launch_mit_vector.unwrap_or(0),
         }
     }
 }
@@ -57,6 +63,7 @@ impl From<&mut DerivedKey> for DerivedKeyReq {
             vmpl: value.vmpl,
             guest_svn: value.guest_svn,
             tcb_version: value.tcb_version,
+            launch_mit_vector: value.launch_mit_vector.unwrap_or(0),
         }
     }
 }
@@ -263,7 +270,7 @@ mod test {
     #[test]
     fn test_derived_key_req_conversion() {
         // Create a mock DerivedKey
-        let derived_key = DerivedKey::new(false, GuestFieldSelect(0x1234), 2, 1, 100);
+        let derived_key = DerivedKey::new(false, GuestFieldSelect(0x1234), 2, 1, 100, Some(123));
 
         // Test From<DerivedKey>
         let req: DerivedKeyReq = derived_key.into();
@@ -273,6 +280,7 @@ mod test {
         assert_eq!(req.vmpl, 2);
         assert_eq!(req.guest_svn, 1);
         assert_eq!(req.tcb_version, 100);
+        assert_eq!(req.launch_mit_vector, 123);
 
         // Test From<&mut DerivedKey>
         let mut derived_key = derived_key;
@@ -283,6 +291,7 @@ mod test {
         assert_eq!(req.vmpl, 2);
         assert_eq!(req.guest_svn, 1);
         assert_eq!(req.tcb_version, 100);
+        assert_eq!(req.launch_mit_vector, 123);
     }
 
     #[test]

--- a/tests/guest.rs
+++ b/tests/guest.rs
@@ -27,7 +27,7 @@ fn get_ext_report() {
 #[cfg_attr(not(guest), ignore)]
 #[test]
 fn get_derived_key() {
-    let derived_key = DerivedKey::new(false, GuestFieldSelect(1), 0, 0, 0);
+    let derived_key = DerivedKey::new(false, GuestFieldSelect(1), 0, 0, 0, None);
 
     let mut fw = Firmware::open().unwrap();
 
@@ -43,6 +43,7 @@ fn guest_fw_error() {
         0xFFFFFFFF,
         0xFFFFFFFF,
         0xFFFFFFFFFFFFFFFF,
+        Some(0xFFFFFFFFFFFFFFFF),
     );
 
     let mut fw = Firmware::open().unwrap();


### PR DESCRIPTION
The new 1.58 firmware specification has been released, introducing changes to both the attestation report and key derivation features.

Attestation Report Changes:
Two new fields have been added: launch_mit_vector and current_mit_vector. These vectors reflect mitigations that may or may not be present on the system. Additionally, a new enablement bit for SEV-TIO has been added to the PlatformInfo structure. The attestation report version is now bumped to version 5. (Note: Version 4 remains under AMD embargo, so specifics cannot be disclosed.)

Key Derivation Changes:
A new field, launch_mit_vector, has been added to the key derivation request structure. This allows a mitigation vector to be mixed into the derived key. As a result, the message key request has been bumped to version 2. Version 2 requests require a mit_vector value; if a version 1 request is used, the mit_vector defaults to zero.

Parsing Improvements:
The attestation report byte parsing logic has been updated. Previously, there were separate variants for each version (pre-Turin and Turin). Now, the write_tcb and parse_tcb functions are used more effectively. Once the processor generation is determined, the appropriate TCB layout can be applied. Since TCB layout is the main difference between pre-Turin and Turin+ attestation reports, this change allows us to maintain a single report variant per version.