### PR TITLE
Fix: Update Config structures to accurately reflect TCBs

### DIFF
--- a/src/firmware/host/mod.rs
+++ b/src/firmware/host/mod.rs
@@ -42,7 +42,7 @@ use std::convert::TryInto;
 use super::linux::host::types::SnpCommit;
 
 #[cfg(all(target_os = "linux", feature = "snp"))]
-use super::linux::host::types::SnpPlatformStatus as FFISnpPlatformStatus;
+use super::linux::host::types::{SnpPlatformStatus as FFISnpPlatformStatus, SnpSetConfig};
 
 /// The CPU-unique identifier for the platform.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -268,7 +268,8 @@ impl Firmware {
     /// ```
     #[cfg(feature = "snp")]
     pub fn snp_set_config(&mut self, new_config: Config) -> Result<(), UserApiError> {
-        let mut binding = new_config.try_into()?;
+        let mut binding: SnpSetConfig = new_config.try_into()?;
+
         let mut cmd_buf = Command::from_mut(&mut binding);
 
         SNP_SET_CONFIG

--- a/src/firmware/linux/host/types/snp.rs
+++ b/src/firmware/linux/host/types/snp.rs
@@ -229,8 +229,8 @@ pub struct SnpCommit {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C, packed)]
 pub struct SnpSetConfig {
-    /// The TCB_VERSION to report in guest attestation reports.
-    pub reported_tcb: UAPI::TcbVersion,
+    /// The bytes corresponding to the TCB_VERSION to report in guest attestation reports.
+    pub reported_tcb: [u8; 8],
 
     /// mask_id [0] : whether chip id is present in attestation reports or not  
     /// mask_id [1]: whether attestation reports are signed or not

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -176,8 +176,9 @@ mod snp {
     #[cfg_attr(not(all(host, feature = "dangerous_hw_tests")), ignore)]
     #[test]
     #[serial]
-    fn set_config() {
+    fn set_config_generation() {
         let mut fw: Firmware = Firmware::open().unwrap();
+
         fw.snp_set_config(Config::default()).unwrap();
     }
 


### PR DESCRIPTION
When we updated the TCB structure, we overlooked modifying the config-related structures to account for differences in TCB layout across CPU generations.
This commit ensures that raw TCB bytes are correctly constructed for the FFI layer, and that conversions from the user-level structure to the FFI format use the appropriate TCB structure based on the processor generation.