### PR TITLE
Bumping crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.2.1"
+version = "6.3.0"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "6.2.1"
+version = "6.3.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",


### PR DESCRIPTION
@larrydewey @tylerfanelli 

After https://github.com/virtee/sev/pull/316 get merged, we want to cut a new release. The question is if we want to cut 6.3.0 or 7.0.0? 
PR https://github.com/virtee/sev/pull/316 is going to introduce some API changes, but as far as I can tell, that API has never been functional—some of the structure initializations needed changes to actually make it work. I suspect it hasn't been widely used because of this, although we have had people reach out asking how to perform the VLEK load.
The question is: do we need to bump the version to 7.0 after this change, or would it be acceptable to move forward with a 6.3 release instead? We’d prefer to avoid another major release at this time, so we’re checking in to hear everyone’s thoughts.
