### PR TITLE
Refactor: Open up Generation -> CerXXXCaChain converters

### DIFF
--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -308,6 +308,7 @@ pub(crate) fn write_tcb(
     h.write_bytes(match generation {
         Generation::Milan | Generation::Genoa => tcb.to_legacy_bytes(),
         Generation::Turin => tcb.to_turin_bytes(),
+        #[cfg(feature = "sev")]
         _ => {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
@@ -327,6 +328,7 @@ pub(crate) fn parse_tcb(
             Ok(TcbVersion::from_legacy_bytes(&stepper.parse_bytes()?))
         }
         Generation::Turin => Ok(TcbVersion::from_turin_bytes(&stepper.parse_bytes()?)),
+        #[cfg(feature = "sev")]
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "Unsupported Processor Generation for TCB parsing",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,16 +116,24 @@ pub use util::cached_chain;
 #[cfg(all(feature = "openssl", feature = "sev"))]
 use certs::sev::sev;
 
-#[cfg(all(feature = "sev", feature = "openssl"))]
+#[cfg(feature = "sev")]
 use certs::sev::ca::{Certificate, Chain as CertSevCaChain};
 
-#[cfg(all(not(feature = "sev"), feature = "snp", feature = "openssl"))]
+#[cfg(all(
+    not(feature = "sev"),
+    feature = "snp",
+    any(feature = "openssl", feature = "crypto_nossl")
+))]
 use certs::snp::ca::Chain as CertSnpCaChain;
 
-#[cfg(all(feature = "sev", feature = "openssl"))]
+#[cfg(feature = "sev")]
 use certs::sev::builtin as SevBuiltin;
 
-#[cfg(all(not(feature = "sev"), feature = "snp", feature = "openssl"))]
+#[cfg(all(
+    not(feature = "sev"),
+    feature = "snp",
+    any(feature = "openssl", feature = "crypto_nossl")
+))]
 use certs::snp::builtin as SnpBuiltin;
 
 #[cfg(any(feature = "sev", feature = "snp"))]
@@ -293,7 +301,7 @@ impl Generation {
     }
 }
 
-#[cfg(all(feature = "sev", feature = "openssl"))]
+#[cfg(feature = "sev")]
 impl From<Generation> for CertSevCaChain {
     fn from(generation: Generation) -> CertSevCaChain {
         use codicon::Decoder;
@@ -318,7 +326,11 @@ impl From<Generation> for CertSevCaChain {
     }
 }
 
-#[cfg(all(not(feature = "sev"), feature = "snp", feature = "openssl"))]
+#[cfg(all(
+    not(feature = "sev"),
+    feature = "snp",
+    any(feature = "openssl", feature = "crypto_nossl")
+))]
 impl From<Generation> for CertSnpCaChain {
     fn from(gen: Generation) -> CertSnpCaChain {
         let (ark, ask) = match gen {


### PR DESCRIPTION
There is no reason to keep the `From<Generation> for CertSevCaChain` and `From<Generation> for CertSnpCaChain` implementations gated on the `openssl` feature. `CertSevCaChain` is available behind the `sev` feature and `CertSnpCaChain` is available when either `openssl` or `crypto_nossl` is active besides `sev`.