### PR TITLE
Refactor: removing CODICON crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,12 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "codicon"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,7 +1607,6 @@ dependencies = [
  "bitfield",
  "bitflags 2.9.0",
  "byteorder",
- "codicon",
  "dirs",
  "hex",
  "iocuddle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ openssl = { version = "0.10", optional = true, features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 bitflags = "2.9.0"
-codicon = "3.0"
 dirs = "^6.0"
 serde-big-array = "0.5.1"
 static_assertions = "^1.1.0"

--- a/src/certs/sev/ca/cert/mod.rs
+++ b/src/certs/sev/ca/cert/mod.rs
@@ -40,7 +40,7 @@ impl std::fmt::Debug for Certificate {
 #[cfg(feature = "openssl")]
 impl std::fmt::Display for Certificate {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use codicon::Encoder;
+        use crate::Encoder;
         use std::fmt::Error;
 
         let key = PublicKey::try_from(self).or(Err(Error))?;
@@ -81,7 +81,7 @@ impl<U: Copy + Into<crate::certs::sev::Usage>> PartialEq<U> for Certificate {
     }
 }
 
-impl codicon::Decoder<()> for Certificate {
+impl Decoder<()> for Certificate {
     type Error = Error;
 
     fn decode(mut reader: impl Read, params: ()) -> Result<Self> {
@@ -94,7 +94,7 @@ impl codicon::Decoder<()> for Certificate {
     }
 }
 
-impl codicon::Encoder<()> for Certificate {
+impl Encoder<()> for Certificate {
     type Error = Error;
 
     fn encode(&self, writer: impl Write, _: ()) -> Result<()> {
@@ -106,7 +106,7 @@ impl codicon::Encoder<()> for Certificate {
 }
 
 #[cfg(feature = "openssl")]
-impl codicon::Encoder<Body> for Certificate {
+impl Encoder<Body> for Certificate {
     type Error = Error;
 
     fn encode(&self, writer: impl Write, _: Body) -> Result<()> {
@@ -122,7 +122,7 @@ impl<'de> de::Deserialize<'de> for Certificate {
     where
         D: de::Deserializer<'de>,
     {
-        use codicon::Decoder;
+        use Decoder;
 
         let bytes = ByteBuf::deserialize(deserializer)?;
         Self::decode(bytes.as_slice(), ()).map_err(serde::de::Error::custom)

--- a/src/certs/sev/ca/cert/v1.rs
+++ b/src/certs/sev/ca/cert/v1.rs
@@ -119,7 +119,7 @@ macro_rules! traits {
                 }
             }
 
-            impl codicon::Decoder<Preamble> for Contents<[u8; $size]> {
+            impl Decoder<Preamble> for Contents<[u8; $size]> {
                 type Error = Error;
 
                 fn decode(mut reader: impl Read, preamble: Preamble) -> Result<Self> {
@@ -188,7 +188,7 @@ impl PartialEq for Certificate {
     }
 }
 
-impl codicon::Decoder<()> for Certificate {
+impl Decoder<()> for Certificate {
     type Error = Error;
 
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
@@ -207,7 +207,7 @@ impl codicon::Decoder<()> for Certificate {
     }
 }
 
-impl codicon::Encoder<()> for Certificate {
+impl Encoder<()> for Certificate {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {
@@ -219,7 +219,7 @@ impl codicon::Encoder<()> for Certificate {
 }
 
 #[cfg(feature = "openssl")]
-impl codicon::Encoder<super::Body> for Certificate {
+impl Encoder<super::Body> for Certificate {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: super::Body) -> Result<()> {

--- a/src/certs/sev/ca/chain.rs
+++ b/src/certs/sev/ca/chain.rs
@@ -17,7 +17,7 @@ pub struct Chain {
     pub ark: Certificate,
 }
 
-impl codicon::Decoder<()> for Chain {
+impl Decoder<()> for Chain {
     type Error = Error;
 
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
@@ -35,7 +35,7 @@ impl codicon::Decoder<()> for Chain {
     }
 }
 
-impl codicon::Encoder<()> for Chain {
+impl Encoder<()> for Chain {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {

--- a/src/certs/sev/chain.rs
+++ b/src/certs/sev/chain.rs
@@ -17,7 +17,7 @@ pub struct Chain {
     pub sev: sev::Chain,
 }
 
-impl codicon::Decoder<()> for Chain {
+impl Decoder<()> for Chain {
     type Error = Error;
 
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
@@ -27,7 +27,7 @@ impl codicon::Decoder<()> for Chain {
     }
 }
 
-impl codicon::Encoder<()> for Chain {
+impl Encoder<()> for Chain {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {

--- a/src/certs/sev/crypto.rs
+++ b/src/certs/sev/crypto.rs
@@ -17,7 +17,7 @@ impl<U> PrivateKey<U> {
 macro_rules! prv_decoder {
     ($($cert:path => $usage:path),+) => {
         $(
-            impl codicon::Decoder<&$cert> for PrivateKey<$usage> {
+            impl Decoder<&$cert> for PrivateKey<$usage> {
                 type Error = Error;
 
                 fn decode(mut reader: impl Read, params: &$cert) -> Result<Self> {
@@ -47,7 +47,7 @@ prv_decoder! {
     ca::Certificate => ca::Usage
 }
 
-impl<U> codicon::Encoder<()> for PrivateKey<U> {
+impl<U> Encoder<()> for PrivateKey<U> {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {
@@ -98,11 +98,7 @@ where
     Usage: PartialEq<U>,
 {
     /// Verifies the provided signatures signed or did not sign the message digest provided.
-    pub fn verify(
-        &self,
-        msg: &impl codicon::Encoder<Body, Error = Error>,
-        sig: &Signature,
-    ) -> Result<()> {
+    pub fn verify(&self, msg: &impl Encoder<Body, Error = Error>, sig: &Signature) -> Result<()> {
         let usage = sig.usage == self.usage;
         let kind = sig.kind == self.key.id();
         let hash = sig.hash == self.hash;

--- a/src/certs/sev/mod.rs
+++ b/src/certs/sev/mod.rs
@@ -21,6 +21,8 @@ use crate::util::*;
 #[cfg(feature = "openssl")]
 use util::*;
 
+use crate::{Decoder, Encoder};
+
 use std::{
     convert::*,
     io::{Error, ErrorKind, Read, Result, Write},

--- a/src/certs/sev/sev/cert/mod.rs
+++ b/src/certs/sev/sev/cert/mod.rs
@@ -31,8 +31,8 @@ impl std::fmt::Debug for Certificate {
 #[cfg(feature = "openssl")]
 impl std::fmt::Display for Certificate {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use codicon::Encoder;
         use std::fmt::Error;
+        use Encoder;
 
         let key = PublicKey::try_from(self).or(Err(Error))?;
 
@@ -72,7 +72,7 @@ impl<U: Copy + Into<crate::certs::sev::Usage>> PartialEq<U> for Certificate {
     }
 }
 
-impl codicon::Decoder<()> for Certificate {
+impl Decoder<()> for Certificate {
     type Error = Error;
 
     fn decode(mut reader: impl Read, params: ()) -> Result<Self> {
@@ -85,7 +85,7 @@ impl codicon::Decoder<()> for Certificate {
     }
 }
 
-impl codicon::Encoder<()> for Certificate {
+impl Encoder<()> for Certificate {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {
@@ -97,7 +97,7 @@ impl codicon::Encoder<()> for Certificate {
 }
 
 #[cfg(feature = "openssl")]
-impl codicon::Encoder<Body> for Certificate {
+impl Encoder<Body> for Certificate {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: Body) -> Result<()> {
@@ -113,7 +113,7 @@ impl<'de> de::Deserialize<'de> for Certificate {
     where
         D: de::Deserializer<'de>,
     {
-        use codicon::Decoder;
+        use Decoder;
 
         let bytes = ByteBuf::deserialize(deserializer)?;
         Self::decode(bytes.as_slice(), ()).map_err(serde::de::Error::custom)

--- a/src/certs/sev/sev/cert/v1/mod.rs
+++ b/src/certs/sev/sev/cert/v1/mod.rs
@@ -29,7 +29,7 @@ impl Certificate {
     }
 }
 
-impl codicon::Decoder<()> for Certificate {
+impl Decoder<()> for Certificate {
     type Error = Error;
 
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {

--- a/src/certs/sev/sev/chain.rs
+++ b/src/certs/sev/sev/chain.rs
@@ -23,7 +23,7 @@ pub struct Chain {
     pub cek: Certificate,
 }
 
-impl codicon::Decoder<()> for Chain {
+impl Decoder<()> for Chain {
     type Error = Error;
 
     fn decode(mut reader: impl Read, _: ()) -> Result<Self> {
@@ -51,7 +51,7 @@ impl codicon::Decoder<()> for Chain {
     }
 }
 
-impl codicon::Encoder<()> for Chain {
+impl Encoder<()> for Chain {
     type Error = Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> Result<()> {

--- a/src/firmware/host/types/sev.rs
+++ b/src/firmware/host/types/sev.rs
@@ -2,9 +2,10 @@
 
 //! Operations for managing the SEV platform.
 
-pub use crate::firmware::linux::host::types::PlatformStatusFlags;
-
 use crate::firmware::host::State;
+pub use crate::firmware::linux::host::types::PlatformStatusFlags;
+use crate::util::{array::Array, TypeLoad, TypeSave};
+use crate::{Decoder, Encoder};
 
 #[cfg(feature = "openssl")]
 use std::convert::TryInto;
@@ -18,9 +19,6 @@ use crate::certs::sev::{
 #[cfg(feature = "openssl")]
 use openssl::{ec::EcKey, ecdsa::EcdsaSig, pkey::Public, sha::Sha256};
 
-use crate::util::{TypeLoad, TypeSave};
-
-use crate::util::array::Array;
 use serde::{Deserialize, Serialize};
 
 use std::{
@@ -77,7 +75,7 @@ impl std::fmt::Display for Build {
     }
 }
 
-impl codicon::Decoder<()> for Build {
+impl Decoder<()> for Build {
     type Error = std::io::Error;
 
     fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
@@ -85,7 +83,7 @@ impl codicon::Decoder<()> for Build {
     }
 }
 
-impl codicon::Encoder<()> for Build {
+impl Encoder<()> for Build {
     type Error = std::io::Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -8,6 +8,7 @@ use crate::{
     error::{FirmwareError, SevError},
     firmware::host::Version,
     util::{TypeLoad, TypeSave},
+    Decoder, Encoder,
 };
 
 #[cfg(target_os = "linux")]
@@ -377,7 +378,7 @@ pub struct Start {
     pub session: Session,
 }
 
-impl codicon::Decoder<()> for Start {
+impl Decoder<()> for Start {
     type Error = std::io::Error;
 
     fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
@@ -385,7 +386,7 @@ impl codicon::Decoder<()> for Start {
     }
 }
 
-impl codicon::Encoder<()> for Start {
+impl Encoder<()> for Start {
     type Error = std::io::Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
@@ -454,7 +455,7 @@ pub struct Secret {
     pub ciphertext: Vec<u8>,
 }
 
-impl codicon::Decoder<()> for Secret {
+impl Decoder<()> for Secret {
     type Error = std::io::Error;
 
     fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
@@ -465,7 +466,7 @@ impl codicon::Decoder<()> for Secret {
     }
 }
 
-impl codicon::Encoder<()> for Secret {
+impl Encoder<()> for Secret {
     type Error = std::io::Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
@@ -485,7 +486,7 @@ pub struct Measurement {
     pub mnonce: [u8; 16],
 }
 
-impl codicon::Decoder<()> for Measurement {
+impl Decoder<()> for Measurement {
     type Error = std::io::Error;
 
     fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
@@ -493,7 +494,7 @@ impl codicon::Decoder<()> for Measurement {
     }
 }
 
-impl codicon::Encoder<()> for Measurement {
+impl Encoder<()> for Measurement {
     type Error = std::io::Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,8 +288,6 @@ impl Generation {
 #[cfg(all(feature = "sev", feature = "openssl"))]
 impl From<Generation> for CertSevCaChain {
     fn from(generation: Generation) -> CertSevCaChain {
-        use codicon::Decoder;
-
         let (ark, ask) = match generation {
             #[cfg(feature = "sev")]
             Generation::Naples => (SevBuiltin::naples::ARK, SevBuiltin::naples::ASK),
@@ -414,4 +412,44 @@ impl Generation {
             Self::Turin => "Turin".to_string(),
         }
     }
+}
+
+/// Trait used to express encoding relationships.
+pub trait Encoder<T> {
+    /// The error type returned when encoding fails.
+    ///
+    /// This is typically an [`std::io::Error`] if the encoding process
+    /// involves I/O, but it can be any type that implements [`std::error::Error`].
+    /// Implementors should use an error type that captures all possible
+    /// failure modes for their encoding logic, including I/O failures
+    /// and serialization errors.
+    type Error;
+
+    /// Encodes to the writer with the given parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if writing to the output fails or
+    /// if the value cannot be encoded for any reason.
+    fn encode(&self, writer: impl Write, params: T) -> Result<(), Self::Error>;
+}
+
+/// Trait used to express decoding relationships.
+pub trait Decoder<T>: Sized {
+    /// The error type returned when decoding fails.
+    ///
+    /// This is typically an [`std::io::Error`] if the decoding process
+    /// involves I/O, but it can be any type that implements [`std::error::Error`].
+    /// Implementors should use an error type that captures all possible
+    /// failure modes for their decoding logic, including I/O failures,
+    /// data corruption, or invalid formats.
+    type Error;
+
+    /// Decodes from the reader with the given parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if reading from the input fails or
+    /// if the value cannot be decoded due to invalid or incomplete data.
+    fn decode(reader: impl Read, params: T) -> Result<Self, Self::Error>;
 }

--- a/src/session/key.rs
+++ b/src/session/key.rs
@@ -39,7 +39,7 @@ impl DerefMut for Key {
     }
 }
 
-impl codicon::Encoder<()> for Key {
+impl Encoder<()> for Key {
     type Error = Error;
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
         writer.write_all(&self.0)?;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -5,7 +5,7 @@
 
 mod key;
 
-use crate::{error::SessionError, firmware::host::Build};
+use crate::{error::SessionError, firmware::host::Build, Encoder};
 
 use super::*;
 

--- a/src/util/cached_chain.rs
+++ b/src/util/cached_chain.rs
@@ -18,7 +18,7 @@ use crate::{
     certs::sev::{ca::Chain as CaChain, Chain as FullChain},
     firmware::host::Firmware,
     sev::Certificate,
-    Generation,
+    Decoder, Generation,
 };
 
 #[cfg(feature = "openssl")]
@@ -34,9 +34,6 @@ use std::{
 
 #[cfg(feature = "openssl")]
 use std::io::Cursor;
-
-#[cfg(feature = "openssl")]
-use codicon::Decoder;
 
 fn append_rest<P: AsRef<Path>>(path: P) -> PathBuf {
     let mut path = path.as_ref().to_path_buf();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,7 +5,6 @@
 pub mod array;
 pub mod cached_chain;
 mod impl_const_id;
-#[cfg(feature = "snp")]
 pub mod parser;
 
 use std::{

--- a/src/vmsa/mod.rs
+++ b/src/vmsa/mod.rs
@@ -3,10 +3,7 @@
 //! Types and abstractions regarding Virtual Machine Save Areas (VMSAs).
 
 #![allow(dead_code)]
-
-use codicon::{Decoder, Encoder};
-
-use crate::util::array::Array;
+use crate::{util::array::Array, Decoder, Encoder};
 
 use super::{
     util::{TypeLoad, TypeSave},
@@ -304,7 +301,7 @@ pub struct Vmsa {
     x87_state_gpa: u64,
 }
 
-impl codicon::Decoder<()> for Vmsa {
+impl Decoder<()> for Vmsa {
     type Error = std::io::Error;
 
     fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
@@ -312,7 +309,7 @@ impl codicon::Decoder<()> for Vmsa {
     }
 }
 
-impl codicon::Encoder<()> for Vmsa {
+impl Encoder<()> for Vmsa {
     type Error = std::io::Error;
 
     fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {

--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -13,7 +13,7 @@ mod sev {
     #[test]
     fn test_for_verify_false_positive() {
         use ::sev::certs::sev::*;
-        use codicon::Decoder;
+        use ::sev::Decoder;
 
         // https://github.com/enarx/enarx/issues/520
         let naples_cek = sev::Certificate::decode(&mut &naples::CEK[..], ()).unwrap();

--- a/tests/naples/mod.rs
+++ b/tests/naples/mod.rs
@@ -17,4 +17,4 @@ const PDH: &[u8] = include_bytes!("pdh.cert");
 use ::sev::certs::sev::*;
 
 #[allow(unused_imports)]
-use codicon::*;
+use ::sev::{Decoder, Encoder};

--- a/tests/rome/mod.rs
+++ b/tests/rome/mod.rs
@@ -13,4 +13,4 @@ const PEK: &[u8] = include_bytes!("pek.cert");
 const PDH: &[u8] = include_bytes!("pdh.cert");
 
 use ::sev::certs::sev::*;
-use codicon::{Decoder, Encoder};
+use ::sev::{Decoder, Encoder};

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -4,8 +4,7 @@
 
 #[cfg(all(target_os = "linux", feature = "sev"))]
 mod initialized {
-    use ::sev::{certs::sev::builtin::naples::*, certs::sev::*, launch, session::Session};
-    use codicon::Decoder;
+    use ::sev::{certs::sev::builtin::naples::*, certs::sev::*, launch, session::Session, Decoder};
     use std::convert::*;
 
     #[test]


### PR DESCRIPTION
Codicon has not been maintained for 5 years and only defines two traits for encoding and decoding types. We were exposing these traits externally, forcing users of virtee to also depend on Codicon. By inlining the traits into our main library, we can keep exposing them publicly while removing the Codicon dependency.