### PR TITLE
Allow OpenSSL vendoring to be disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 doc = false
 
 [features]
-default = ["sev", "snp"]
+default = ["sev", "snp", "openssl?/vendored"]
 openssl = ["dep:openssl", "dep:rdrand"]
 hw_tests = []
 dangerous_hw_tests = ["hw_tests", "dep:reqwest", "dep:tokio"]
@@ -48,7 +48,7 @@ crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 iocuddle = "^0.1"
 
 [dependencies]
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
+openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 bitflags = "2.9.0"


### PR DESCRIPTION
We're working with SEV on a platform that is not supported by vendored Openssl (Yocto with OpenEmbedded, not supported by the crate openssl-src, and we spent a couple hours trying to hack together a workaround for vendored OpenSSL to no avail). We've been able to make do with version 6.0.0 for a while, but we're in need to update to 6.2.1 due to https://github.com/virtee/sev/commit/e96d605b672fae3c50fddbf2ae82fb6c1aee7673.

This change preserves the intent of OpenSSL being vendored by default if enabled, but leaves the possibility for dependents to disable OpenSSL vendoring.