### PR TITLE
snp: skip calling CPUID on non-x86 platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,10 +286,17 @@ impl Generation {
     pub fn identify_host_generation() -> Result<Self, std::io::Error> {
         use std::convert::TryInto;
 
-        let raw_cpuid = unsafe { std::arch::x86_64::__cpuid(0x8000_0001) }
+        #[cfg(target_arch = "x86_64")]
+        return unsafe { std::arch::x86_64::__cpuid(0x8000_0001) }
             .eax
-            .to_le_bytes();
-        raw_cpuid.as_slice().try_into()
+            .to_le_bytes()
+            .as_slice()
+            .try_into();
+
+        #[cfg(not(target_arch = "x86_64"))]
+        Err(std::io::Error::other(
+            "Cannot get EPYC generation on non-x86 platform",
+        ))
     }
 }
 


### PR DESCRIPTION
When this crate is used to parse SNP hardware evidence on a non-x86 platform, it will still try to build with cpuid from the x86 crate, which will not be found.

Instead, put cpuid behind a platform config flag. If we are not on x86, don't call cpuid and return an error.

Fixes #326 

As an aside, it seems kind of odd that we call this from the types code. 