### PR TITLE
feat: require `rdrand` only when `sev` feature is on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ doc = false
 
 [features]
 default = ["sev", "snp", "openssl?/vendored"]
-openssl = ["dep:openssl", "dep:rdrand"]
+openssl = ["dep:openssl"]
 hw_tests = []
 dangerous_hw_tests = ["hw_tests", "dep:reqwest", "dep:tokio"]
-sev = []
+sev = ["dep:rdrand"]
 snp = []
 crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 serde = ["dep:serde", "dep:serde-big-array"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use std::{
     io,
 };
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", feature = "sev"))]
 use rdrand::ErrorCode;
 
 use std::os::raw::c_int;
@@ -1119,7 +1119,7 @@ impl std::convert::From<ArrayError> for MeasurementError {
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", feature = "sev"))]
 #[derive(Debug)]
 /// Used to describe errors related to SEV-ES "Sessions".
 pub enum SessionError {
@@ -1133,21 +1133,21 @@ pub enum SessionError {
     IOError(std::io::Error),
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", feature = "sev"))]
 impl From<ErrorCode> for SessionError {
     fn from(value: ErrorCode) -> Self {
         Self::RandError(value)
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", feature = "sev"))]
 impl From<std::io::Error> for SessionError {
     fn from(value: std::io::Error) -> Self {
         Self::IOError(value)
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", feature = "sev"))]
 impl From<ErrorStack> for SessionError {
     fn from(value: ErrorStack) -> Self {
         Self::OpenSSLStack(value)
@@ -1483,7 +1483,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl", feature = "sev"))]
     #[test]
     fn test_openssl_features_complete() {
         // Test CertFormatError


### PR DESCRIPTION
This changes the dependency logic so instead of requiring the `rdrand` dependency when the `openssl` feature is on, it does so when the `sev` feature is on.

The logic here is `rdrand` is only used in the `session` module, which is only enabled [if the `sev` feature flag is on](https://github.com/virtee/sev/blob/main/src/lib.rs#L105-L106). Therefore, while you also need `openssl` to be enabled, it's more accurate to require `rdrand` when you want to use `sev` and not when you're using `openssl` since this code is tied to SEV code than it is to openssl (e.g. this is part of the SEV functionality AFAICT).

The deeper motivation here is that `rdrand` [doesn't work in arm](https://github.com/nagisa/rust_rdrand/issues/20), which is fine in general, but I'm trying to compile some code that is meant to be ran by a normal client outside of a trusted environment, and which needs to validate an SNP attestation report. Given the current setup I can't get this client to run on an arm machine because `rdrand` doesn't build there, which is a pity since it doesn't actually use that code at all.

I'm open to other approaches here, this is just the easiest way that made sense to me. Unfortunately you can't set `rdrand` to only be depended on if both `openssl` and `sev` are set. An alternative could be to have a feature flag that specifies whether to use `rand` or `rdrand` as an RNG backend.