### PR TITLE
Fix: Adding serde_bytes as serde dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,10 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1521,10 +1522,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_bytes"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,6 +1622,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde-big-array",
+ "serde_bytes",
  "serial_test",
  "sha2",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dangerous_hw_tests = ["hw_tests", "dep:reqwest", "dep:tokio"]
 sev = []
 snp = []
 crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
-serde = ["dep:serde", "dep:serde-big-array"]
+serde = ["dep:serde", "dep:serde-big-array", "dep:serde_bytes"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iocuddle = "^0.1"
@@ -51,6 +51,7 @@ iocuddle = "^0.1"
 [dependencies]
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"] , optional = true}
+serde_bytes = {version = "0.11", optional = true}
 bitflags = "2.9.0"
 dirs = "^6.0"
 serde-big-array = {version = "0.5.1", optional = true}


### PR DESCRIPTION
Serde_bytes was accidentally removed, it is still needed as one of the serde dependencies.