### PR TITLE
ci: replace deprecated `macos-13` runner with `macos-15-intel`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
         toolchain:
           - 1.85.0
           - stable
@@ -43,7 +43,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
         toolchain:
           - 1.85.0
           - stable
@@ -69,7 +69,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
           - windows-latest
         toolchain:
           - 1.85.0
@@ -97,7 +97,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
         toolchain:
           - 1.85.0
           - stable
@@ -123,7 +123,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
         toolchain:
           - 1.85.0
           - stable
@@ -149,7 +149,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
           - windows-latest
         toolchain:
           - 1.85.0
@@ -177,7 +177,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
         toolchain:
           - 1.85.0
           - stable
@@ -202,7 +202,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macos-13
+          - macos-15-intel
           - windows-latest
         toolchain:
           - 1.85.0


### PR DESCRIPTION
The current `macos-13` runner (macOS with arch x86_64) is deprecated and no longer maintained. This PR updates the GitHub Actions workflow `test.yml` to replace deprecated `macos-13` with `macos-15-intel`, which is the latest Intel-based macOS runner.

### References
- [GitHub Changelog (July 11, 2025)](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/)
- [GitHub Actions Runner Images](https://github.com/actions/runner-images/blob/de257bbc470884bf0082818076a505183c5cdc3f/README.md)
