### PR TITLE
Add From implementation to Certificate when cert_nossl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .vscode/
+.zed/

--- a/src/certs/snp/cert_nossl.rs
+++ b/src/certs/snp/cert_nossl.rs
@@ -62,6 +62,11 @@ impl Verifiable for (&Certificate, &Certificate) {
 }
 
 impl Certificate {
+    /// Gets a reference to the X509 certificate inside
+    pub fn cert(&self) -> &x509_cert::Certificate {
+        &self.0
+    }
+
     /// Create a Certificate from a PEM-encoded X509 structure.
     pub fn from_pem(pem: &[u8]) -> Result<Self> {
         let cert = x509_cert::Certificate::from_pem(pem)
@@ -105,4 +110,16 @@ impl Certificate {
 
 fn io_error_other<S: Into<String>>(error: S) -> io::Error {
     io::Error::new(ErrorKind::Other, error.into())
+}
+
+impl From<x509_cert::Certificate> for Certificate {
+    fn from(value: x509_cert::Certificate) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Certificate> for x509_cert::Certificate {
+    fn from(Certificate(cert): Certificate) -> Self {
+        cert
+    }
 }

--- a/src/certs/snp/cert_nossl.rs
+++ b/src/certs/snp/cert_nossl.rs
@@ -62,11 +62,6 @@ impl Verifiable for (&Certificate, &Certificate) {
 }
 
 impl Certificate {
-    /// Gets a reference to the X509 certificate inside
-    pub fn cert(&self) -> &x509_cert::Certificate {
-        &self.0
-    }
-
     /// Create a Certificate from a PEM-encoded X509 structure.
     pub fn from_pem(pem: &[u8]) -> Result<Self> {
         let cert = x509_cert::Certificate::from_pem(pem)


### PR DESCRIPTION
The `Certificate` implementation under cert_nossl.rs (the one used when the cert_nossl feature is enabled) is missing a From implementation between the `Certificate` wrapper and the inner `x509_cert::Certificate`

I also bumped the minor version as this does not break current APIs.

On a side note, the currently implemented From<&Certificate> (and the other way around) in the openssl implementation are wrong. Cloning should not be done implicitly inside From implementation.

I addede a cert method returning a reference to the inner type to support cloning explicitly the x509_cert certificate type instead of cloning it implicitly via `.into()`