### PR TITLE
chore: include page_swap_disabled bitfield in AttestationReport comments

### DIFF
--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -238,6 +238,7 @@ impl ByteParser<()> for ReportVariant {
 /// The Alias_Check_Complete field in the PlatformInfo field
 /// Added in version 5:
 /// The launch_mit_vector and current_mit_vector fields
+/// The page_swap_disabled field in the GuestPolicy field
 /// The SEV-TIO field in the PlatformInfo field
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This pull request just updates the comment above `AttestationReport` in `firmware/guest/types/snp.rs` to include the missing format‐change entry: the `page_swap_disabled` bitfield in the `GuestPolicy` struct, added in Report Version 5 (SEV FW ABI Rev 1.58) as a mitigation status for the Heracles Attack.

There are no functional changes.