### PR TITLE
Lax parser feature for attestation reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,3 +213,28 @@ jobs:
             flag: --release
         features:
           - crypto_nossl
+
+  sw-lax-parser:
+    name: sw lax-parser ${{ matrix.runner }} ${{ matrix.toolchain }} ${{ matrix.profile.name }} ${{ matrix.features }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - run: cargo test ${{ matrix.profile.flag }} --features=lax-parser
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - macos-15-intel
+          - windows-latest
+        toolchain:
+          - 1.85.0
+          - stable
+        profile:
+          - name: debug
+          - name: release
+            flag: --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ sev = ["dep:rdrand"]
 snp = []
 crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 serde = ["dep:serde", "dep:serde-big-array", "dep:serde_bytes"]
+lax-parser = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iocuddle = "^0.1"

--- a/src/util/parser_helper/read_ext.rs
+++ b/src/util/parser_helper/read_ext.rs
@@ -44,6 +44,25 @@ pub trait ReadExt: Read {
         }
         Ok(self)
     }
+
+    #[cfg(not(feature = "lax-parser"))]
+    /// Read N bytes and verify they are zero.
+    fn read_reserved_bytes<const N: usize>(&mut self) -> Result<[u8; N], std::io::Error>
+    where
+        Self: Sized,
+    {
+        self.skip_bytes::<N>()?;
+        Ok([0; N])
+    }
+
+    #[cfg(feature = "lax-parser")]
+    /// Read N bytes.
+    fn read_reserved_bytes<const N: usize>(&mut self) -> Result<[u8; N], std::io::Error>
+    where
+        Self: Sized,
+    {
+        <[u8; N]>::decode(self, ())
+    }
 }
 
 impl<R> ReadExt for R where R: Read {}


### PR DESCRIPTION
The parser strictly checks reserved areas to be zero (even though the specification does not even require that for all of them). This is an issue when parsing newer versions of attestation reports where those areas might not be reserved anymore. The `lax-parser` feature disables that check.

`AttestationReport` actually reads and writes reserved bytes now.

Closes #343