### PR TITLE
feat: introduce unsafe_parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ sev = ["dep:rdrand"]
 snp = []
 crypto_nossl = ["dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 serde = ["dep:serde", "dep:serde-big-array", "dep:serde_bytes"]
+unsafe_parser = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iocuddle = "^0.1"

--- a/src/util/parser_helper/read_ext.rs
+++ b/src/util/parser_helper/read_ext.rs
@@ -33,6 +33,7 @@ pub trait ReadExt: Read {
             while remaining > 0 {
                 let n = remaining.min(CHUNK);
                 self.read_exact(&mut buf[..n])?;
+                #[cfg(not(feature = "unsafe_parser"))]
                 if buf[..n].iter().any(|&b| b != 0) {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,


### PR DESCRIPTION
When this feature is enabled, the zero-byte check performed by skip_bytes is disabled. As a result, parsing will no longer fail when fields that are expected to be zero contain non-zero values.

This enables forward compatibility when reserved fields are repurposed in newer report versions. Users enabling this feature must take care to validate reserved fields manually if they rely on their contents for security or correctness.

The approaches of preserving values in reserved fields or treating the report as an opaque blob both have potential. However, based on concerns raised by @cschramm and @hyperfinitism, I think there is a larger design discussion to be had—one that could ultimately change how some of these structs are built and may require a breaking API release. To avoid dependency issues like the one @cshramm pointed out in https://github.com/virtee/sev/pull/370
, I’m hesitant to put such changes behind a feature flag. The alternative—introducing a separate report type—is also not ideal.

I don’t want to block @cshramm any longer, so this change immediately addresses the forward compatibility problem. I’m aware this approach has trade-offs, such as losing access to the parsed bytes of invalid reserved fields. However, since we currently have no appropriate fields to store that data, the report maintains type safety by only exposing known, validated fields. Additionally, the API already returns the raw binary report, so those bytes can still be inspected if needed.

If there are additional functions or features you think would make this more immediately usable, please let me know. I’ll start a separate discussion to explore how we might incorporate @hyperfinitism’s ideas into a future major release.

