### PR TITLE
New report parsing 

### DIFF
--- a/src/certs/snp/mod.rs
+++ b/src/certs/snp/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-/// ECDSA signatures.
-pub mod ecdsa;
+/// Attestation report signature parsing and verification helpers.
+pub mod signature;
 
 #[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 /// Certificate Authority (CA) certificates.

--- a/src/certs/snp/signature/ecdsa.rs
+++ b/src/certs/snp/signature/ecdsa.rs
@@ -61,6 +61,8 @@ impl Decoder<()> for Signature {
     fn decode(reader: &mut impl Read, _: ()) -> Result<Self> {
         let r = reader.read_bytes()?;
         let s = reader.read_bytes()?;
+        // Firmware signature field is 0x200 bytes; after r and s, the remaining bytes are reserved/padding.
+        reader.skip_bytes::<368>()?;
         Ok(Self { r, s })
     }
 }

--- a/src/certs/snp/signature/ecdsa.rs
+++ b/src/certs/snp/signature/ecdsa.rs
@@ -1,26 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 use super::*;
 
-use crate::{
-    parser::{ByteParser, Decoder, Encoder},
-    util::{
-        hexline::HexLine,
-        parser_helper::{ReadExt, WriteExt},
-    },
-};
+use crate::{parser::ByteParser, util::hexline::HexLine};
 
 use std::io::{Read, Result, Write};
 
 #[cfg(feature = "openssl")]
-use crate::certs::snp::{AsLeBytes, FromLe};
+use crate::certs::snp::{AsLeBytes, Certificate, FromLe};
 
 #[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 use std::convert::TryFrom;
 
 #[cfg(feature = "openssl")]
-use openssl::{bn, ecdsa};
+use openssl::{bn, ecdsa, ecdsa::EcdsaSig, sha::Sha384};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -130,16 +123,6 @@ impl From<ecdsa::EcdsaSig> for Signature {
 }
 
 #[cfg(feature = "openssl")]
-impl TryFrom<&[u8]> for Signature {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(value: &[u8]) -> Result<Self> {
-        Ok(ecdsa::EcdsaSig::from_der(value)?.into())
-    }
-}
-
-#[cfg(feature = "openssl")]
 impl TryFrom<&Signature> for ecdsa::EcdsaSig {
     type Error = Error;
 
@@ -166,23 +149,57 @@ impl TryFrom<&Signature> for p384::ecdsa::Signature {
             GenericArray::clone_from_slice(&s_big_endian),
         )
         .map_err(|e| {
-            Error::new(
-                ErrorKind::Other,
-                format!("failed to deserialize signature from scalars: {e:?}"),
-            )
+            Error::other(format!(
+                "failed to deserialize signature from scalars: {e:?}"
+            ))
         })
     }
 }
 
 #[cfg(feature = "openssl")]
-impl TryFrom<&Signature> for Vec<u8> {
-    type Error = Error;
+/// Verify ECDSA signature on attestation report using VEK certificate
+pub fn verify_ecdsa_signature(body: &[u8], signature: &[u8], vek: &Certificate) -> Result<()> {
+    let sev_sig = Signature::from_bytes(signature)?;
 
-    #[inline]
-    fn try_from(value: &Signature) -> Result<Self> {
-        Ok(ecdsa::EcdsaSig::try_from(value)?.to_der()?)
+    let sig: EcdsaSig = EcdsaSig::try_from(&sev_sig)?;
+
+    let mut hasher = Sha384::new();
+    hasher.update(body);
+    let base_digest = hasher.finish();
+
+    let ec = vek.public_key()?.ec_key()?;
+    let signed = sig.verify(&base_digest, &ec)?;
+    match signed {
+        true => Ok(()),
+        false => Err(Error::other("VEK does not sign the attestation report")),
     }
 }
+
+#[cfg(feature = "crypto_nossl")]
+/// Verify ECDSA signature on attestation report using VEK certificate
+pub fn verify_ecdsa_signature(body: &[u8], signature: &[u8], vek: &Certificate) -> Result<()> {
+    let sev_sig = Signature::from_bytes(signature)?;
+
+    let sig = p384::ecdsa::Signature::try_from(&sev_sig).map_err(|e| {
+        std::io::Error::other(format!(
+            "failed to generate signature from raw bytes: {e:?}"
+        ))
+    })?;
+
+    use sha2::Digest;
+    let base_digest = sha2::Sha384::new_with_prefix(body);
+    let verifying_key =
+        p384::ecdsa::VerifyingKey::from_sec1_bytes(vek.public_key_sec1()).map_err(|e| {
+            std::io::Error::other(format!(
+                "failed to deserialize public key from sec1 bytes: {e:?}"
+            ))
+        })?;
+    use p384::ecdsa::signature::DigestVerifier;
+    verifying_key.verify_digest(base_digest, &sig).map_err(|e| {
+        std::io::Error::other(format!("VEK does not sign the attestation report: {e:?}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,29 +279,11 @@ mod tests {
         }
 
         #[test]
-        fn test_try_from_bytes() {
-            let r = BigNum::from_dec_str("123").unwrap();
-            let s = BigNum::from_dec_str("456").unwrap();
-            let ecdsa_sig = ecdsa::EcdsaSig::from_private_components(r, s).unwrap();
-            let der = ecdsa_sig.to_der().unwrap();
-            let sig = Signature::try_from(der.as_slice()).unwrap();
-            assert_ne!(sig.r(), &[0u8; 72]);
-            assert_ne!(sig.s(), &[0u8; 72]);
-        }
-
-        #[test]
         fn test_try_into_ecdsa_sig() {
             let sig: Signature = Default::default();
             let ecdsa_sig: ecdsa::EcdsaSig = (&sig).try_into().unwrap();
             assert_eq!(ecdsa_sig.r().to_vec(), vec![]);
             assert_eq!(ecdsa_sig.s().to_vec(), vec![]);
-        }
-
-        #[test]
-        fn test_try_into_vec() {
-            let sig: Signature = Default::default();
-            let der: Vec<u8> = (&sig).try_into().unwrap();
-            assert!(!der.is_empty());
         }
     }
 

--- a/src/certs/snp/signature/mod.rs
+++ b/src/certs/snp/signature/mod.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    convert::TryFrom,
+    fmt::Display,
+    io::{Read, Write},
+};
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+use std::io::Error;
+
+use crate::{
+    parser::{Decoder, Encoder},
+    util::parser_helper::{ReadExt, WriteExt},
+};
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+use crate::certs::snp::{Certificate, Verifiable};
+
+/// ECDSA algorithm signature
+pub mod ecdsa;
+
+/// Signature algorithms that firmware may use to sign the SEV-SNP attestation report.
+///
+/// The algorithm identifier is encoded in the report body and is therefore derived
+/// from **untrusted bytes**. It MUST NOT be treated as a trust signal on its own.
+/// Authenticity is only established by successfully verifying the report signature.
+///
+/// This enum is intentionally explicit: unknown values are rejected during decoding.
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SignatureAlgorithm {
+    /// ECDSA with SECP384R1 curve
+    EcdsaSecp384r1 = 1,
+}
+
+/// Creates a [`SignatureAlgorithm`] from the numeric algorithm identifier encoded
+/// in the report body.
+///
+/// # Errors
+///
+/// Returns `InvalidData` if `v` does not correspond to a supported algorithm.
+impl TryFrom<u32> for SignatureAlgorithm {
+    type Error = std::io::Error;
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        match v {
+            1 => Ok(SignatureAlgorithm::EcdsaSecp384r1),
+            v => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Unsupported signature algorithm: {}", v),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+impl Verifiable for (SignatureAlgorithm, &[u8], &[u8], &Certificate) {
+    type Output = ();
+
+    fn verify(self) -> Result<Self::Output, std::io::Error> {
+        let (algorithm, body, signature, vek) = self;
+        match algorithm {
+            SignatureAlgorithm::EcdsaSecp384r1 => {
+                ecdsa::verify_ecdsa_signature(body, signature, vek)
+            }
+        }
+    }
+}
+
+impl Encoder<()> for SignatureAlgorithm {
+    fn encode(&self, writer: &mut impl Write, _: ()) -> Result<(), std::io::Error> {
+        match self {
+            SignatureAlgorithm::EcdsaSecp384r1 => writer.write_bytes(1u32, ())?,
+        };
+        Ok(())
+    }
+}
+
+impl Decoder<()> for SignatureAlgorithm {
+    fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
+        let algo: u32 = reader.read_bytes()?;
+        Self::try_from(algo)
+    }
+}
+
+impl Display for SignatureAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignatureAlgorithm::EcdsaSecp384r1 => write!(f, "ECDSA with SECP384R1"),
+        }
+    }
+}

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
-use crate::certs::snp::{Certificate, Chain, Verifiable};
+use crate::certs::snp::{ecdsa::Signature, Certificate, Chain, Verifiable};
 
 use crate::{
-    certs::snp::ecdsa::Signature,
-    error::AttestationReportError,
     firmware::host::TcbVersion,
     parser::{ByteParser, Decoder, Encoder},
     util::{
         hexline::HexLine,
-        parser_helper::{ReadExt, WriteExt},
+        parser_helper::{validate_reserved, ReadExt, WriteExt},
     },
     Generation,
 };
@@ -21,13 +19,10 @@ use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
 use std::{
+    convert::TryFrom,
     fmt::Display,
-    io::{Cursor, Read, Write},
-    ops::Range,
+    io::{Read, Write},
 };
-
-#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
-use std::convert::TryFrom;
 
 #[cfg(feature = "openssl")]
 use std::io::Error;
@@ -36,11 +31,6 @@ use bitfield::bitfield;
 
 #[cfg(feature = "openssl")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
-
-const ATT_REP_FW_LEN: usize = 1184;
-const CHIP_ID_RANGE: Range<usize> = 0x1A0..0x1E0;
-const CPUID_FAMILY_ID_BYTES: usize = 0x188;
-const CPUID_MODEL_ID_BYTES: usize = 0x189;
 
 /// Structure of required data for fetching the derived key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -189,16 +179,115 @@ impl ByteParser<()> for Version {
     const EXPECTED_LEN: Option<usize> = Some(3);
 }
 
-/// Possible variants of the attestation report.
+/// Identifies the firmware-defined format version of an SEV-SNP attestation report.
+///
+/// `ReportVariant` corresponds to the *report layout version* as emitted by
+/// platform firmware. The variant determines:
+///
+/// - Which fields are present in the report body
+/// - How certain fields are interpreted (e.g. TCB layout)
+/// - How platform generation is inferred
+///
+/// This enum is intentionally **narrow and explicit**: only variants currently
+/// understood by the library are represented. Any unknown or future report
+/// versions will be rejected during decoding.
+///
+/// ---
+///
+/// # Version Semantics
+///
+/// | Variant | Firmware Versions | Notes |
+/// |--------:|-------------------|-------|
+/// | `V2` | 2 | Pre-CPUID reports. Platform generation is inferred from the CHIP_ID field. |
+/// | `V3` | 3, 4 | Introduces CPUID fields used for platform identification. |
+/// | `V5` | 5 | Adds mitigation vector fields and additional reserved regions. |
+///
+/// Firmware version values `3` and `4` are treated equivalently and both map to
+/// [`ReportVariant::V3`], as they share an identical report layout.
+///
+/// ---
+///
+/// # Security Considerations
+///
+/// `ReportVariant` only describes the *format* of the report. It does **not**
+/// imply that the report is authentic or trustworthy.
+///
+/// A parsed `ReportVariant` must not be used as a trust signal on its own.
+/// Authenticity is only established after successful cryptographic verification
+/// of the report signature.
+///
+/// ---
+///
+/// # Parsing and Validation
+///
+/// `ReportVariant` is decoded from the first 4 bytes of the report body and
+/// validated during parsing. Unsupported or unknown version values will cause
+/// parsing to fail with an error.
+///
+/// This ensures forward compatibility is explicit and prevents accidental
+/// acceptance of report formats the library does not understand.
+///
+/// ---
+///
+/// # Correct Usage
+///
+/// `ReportVariant` is primarily consumed internally during report parsing to
+/// drive generation inference and conditional field handling.
+///
+/// Consumers should not attempt to construct `ReportVariant` values manually
+/// from untrusted inputs; instead, rely on decoding via [`ReportBody`] or
+/// verified [`Report`] processing.
+///
+/// ---
+///
+/// # Example
+///
+/// ```ignore
+/// let variant = ReportVariant::decode(&mut reader, ())?;
+///
+/// match variant {
+///     ReportVariant::V2 => { /* CHIP_ID-based inference */ }
+///     ReportVariant::V3 => { /* CPUID-based inference */ }
+///     ReportVariant::V5 => { /* mitigation vector fields present */ }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
 pub enum ReportVariant {
-    /// Version 2 of the Attestation Report.
-    V2,
+    /// Version 2 of the attestation report format.
+    ///
+    /// This variant predates CPUID-based platform identification. Platform
+    /// generation is inferred heuristically from the CHIP_ID field.
+    V2 = 2,
 
-    /// Version 3 of the Attestation Report for PreTurin CPUs.
-    V3,
+    /// Version 3 (and firmware version 4) of the attestation report format.
+    ///
+    /// Introduces CPUID family, model, and stepping fields, enabling explicit
+    /// platform identification. Firmware versions `3` and `4` share the same
+    /// report layout and are represented by this variant.
+    V3 = 3,
 
-    /// Version 5 of the Attestation Report
-    V5,
+    /// Version 5 of the attestation report format.
+    ///
+    /// Extends the V3 layout with mitigation vector fields and additional
+    /// reserved regions. Used by newer firmware revisions.
+    V5 = 5,
+}
+
+impl TryFrom<u32> for ReportVariant {
+    type Error = std::io::Error;
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        match v {
+            2 => Ok(ReportVariant::V2),
+            3 | 4 => Ok(ReportVariant::V3),
+            5 => Ok(ReportVariant::V5),
+            unknown_variant => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unsupported report variant: {}", unknown_variant),
+            )),
+        }
+    }
 }
 
 impl Encoder<()> for ReportVariant {
@@ -215,13 +304,7 @@ impl Encoder<()> for ReportVariant {
 impl Decoder<()> for ReportVariant {
     fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
         let version: u32 = reader.read_bytes()?;
-        Ok(match version {
-            0 | 1 => return Err(std::io::ErrorKind::Unsupported.into()),
-            2 => Self::V2,
-            3 | 4 => Self::V3,
-            5 => Self::V5,
-            _ => Self::V5,
-        })
+        Self::try_from(version)
     }
 }
 
@@ -230,290 +313,474 @@ impl ByteParser<()> for ReportVariant {
     const EXPECTED_LEN: Option<usize> = Some(4);
 }
 
-/// Attestation Report for SEV-SNP guests.
-/// These are all the possible fields in the attestation report.
-/// Optional fields are set to none or a value depending on the version the system has.
-/// Added in version 3:
-/// The CPUID Family, Model and Stepping fields
-/// The Alias_Check_Complete field in the PlatformInfo field
-/// Added in version 5:
-/// The launch_mit_vector and current_mit_vector fields
-/// The page_swap_disabled field in the GuestPolicy field
-/// The SEV-TIO field in the PlatformInfo field
-#[repr(C)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+impl Display for ReportVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReportVariant::V2 => write!(f, "V2"),
+            ReportVariant::V3 => write!(f, "V3"),
+            ReportVariant::V5 => write!(f, "V5"),
+        }
+    }
+}
+
+/// A zero-copy view of a raw SEV-SNP attestation report.
+///
+/// This type splits the report into two byte slices:
+/// - `body`: the bytes covered by the report signature
+/// - `signature`: the firmware-provided signature bytes
+///
+/// `Report` does **not** imply authenticity or integrity. It is just a view over
+/// untrusted bytes. Consumers should verify the signature (using [`Verifiable`])
+/// before interpreting any fields from the body.
+///
+/// This design supports a two-phase workflow:
+/// 1) Parse the outer framing to locate the signed body and signature.
+/// 2) Verify the signature over `body`, then parse the verified body into
+///    [`ReportBody`] for typed access.
+///
+/// # Notes
+/// - `Report` borrows from the input buffer (`'a`), so the input bytes must
+///   outlive the `Report`.
+/// - The offsets used by [`Report::from_bytes`] assume the current fixed
+///   firmware report layout and size (1184 bytes).
+#[derive(Debug, Clone, Copy)]
+pub struct Report<'a> {
+    /// The bytes covered by the report signature (bytes 0x00 to 0x2A0).
+    pub body: &'a [u8],
+    /// The signature bytes (0x2A0..0x4A0).
+    pub signature: &'a [u8],
+}
+
+impl<'a> Report<'a> {
+    const REPORT_LEN: usize = 0x4A0; // 1184
+    const BODY_LEN: usize = 0x2A0; // bytes 0x000..=0x29F
+    const SIG_OFF: usize = 0x2A0;
+    const SIG_LEN: usize = 0x200; // bytes 0x2A0..=0x49F
+    /// Parse a raw attestation report into body and signature slices.
+    ///
+    /// This function performs **framing only**:
+    /// - validates the total report length
+    /// - returns borrowed slices for the signed body and signature
+    ///
+    /// It does **not** verify the signature or validate reserved fields.
+    /// Use [`ReportBody::try_from`] (with a certificate or chain) to obtain a
+    /// verified [`ReportBody`].
+    pub fn from_bytes(report: &'a [u8]) -> std::io::Result<Self> {
+        if report.len() != Self::REPORT_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Bad report length",
+            ));
+        };
+
+        Ok(Self {
+            body: &report[..Self::BODY_LEN],
+            signature: &report[Self::SIG_OFF..Self::SIG_OFF + Self::SIG_LEN],
+        })
+    }
+}
+
+#[cfg(feature = "openssl")]
+impl Verifiable for (&Certificate, &Report<'_>) {
+    type Output = ();
+
+    fn verify(self) -> std::io::Result<Self::Output> {
+        let (vek, report) = self;
+
+        let sev_sig = Signature::from_bytes(report.signature)?;
+
+        let sig: EcdsaSig = EcdsaSig::try_from(&sev_sig)?;
+
+        let mut hasher = Sha384::new();
+        hasher.update(report.body);
+        let base_digest = hasher.finish();
+
+        let ec = vek.public_key()?.ec_key()?;
+        let signed = sig.verify(&base_digest, &ec)?;
+        match signed {
+            true => Ok(()),
+            false => Err(Error::other("VEK does not sign the attestation report")),
+        }
+    }
+}
+
+#[cfg(feature = "crypto_nossl")]
+impl Verifiable for (&Certificate, &Report<'_>) {
+    type Output = ();
+
+    fn verify(self) -> std::io::Result<Self::Output> {
+        // According to Chapter 3 of the Versioned Chip Endorsement Key (VCEK) Certificate and the Versioned Loaded Endorsement Key (VLEK)
+        // Certificate specifications, both Versioned Endorsement Key certificates certify an ECDSA public key on curve P-384,
+        // with the signature hash algorithm being SHA-384.
+
+        let (vek, report) = self;
+
+        let sev_sig = Signature::from_bytes(report.signature)?;
+
+        let sig = p384::ecdsa::Signature::try_from(&sev_sig).map_err(|e| {
+            std::io::Error::other(format!(
+                "failed to generate signature from raw bytes: {e:?}"
+            ))
+        })?;
+
+        use sha2::Digest;
+        let base_digest = sha2::Sha384::new_with_prefix(report.body);
+        let verifying_key = p384::ecdsa::VerifyingKey::from_sec1_bytes(vek.public_key_sec1())
+            .map_err(|e| {
+                std::io::Error::other(format!(
+                    "failed to deserialize public key from sec1 bytes: {e:?}"
+                ))
+            })?;
+        use p384::ecdsa::signature::DigestVerifier;
+        verifying_key.verify_digest(base_digest, &sig).map_err(|e| {
+            std::io::Error::other(format!("VEK does not sign the attestation report: {e:?}"))
+        })
+    }
+}
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+impl Verifiable for (&Chain, &Report<'_>) {
+    type Output = ();
+
+    fn verify(self) -> std::io::Result<()> {
+        let (chain, report) = self;
+        let vek = chain.verify()?;
+        (vek, report).verify()
+    }
+}
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+/// Verifies `report` with `vek` and returns a parsed [`ReportBody`].
+impl<'a> TryFrom<(&Report<'a>, &Certificate)> for ReportBody<'a> {
+    type Error = std::io::Error;
+
+    fn try_from((report, vek): (&Report<'a>, &Certificate)) -> Result<Self, Self::Error> {
+        (vek, report).verify()?;
+        ReportBody::from_bytes(report.body)
+    }
+}
+
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
+/// Verifies `report` with `chain` and returns a parsed [`ReportBody`].
+///
+/// This is the **recommended** way to obtain a `ReportBody`, because it
+/// enforces signature verification before parsing typed fields.
+impl<'a> TryFrom<(&Report<'a>, &Chain)> for ReportBody<'a> {
+    type Error = std::io::Error;
+
+    fn try_from((report, chain): (&Report<'a>, &Chain)) -> Result<Self, Self::Error> {
+        (chain, report).verify()?;
+        ReportBody::from_bytes(report.body)
+    }
+}
+
+/// A zero-copy view of the attestation report body.
+/// All byte-arrayfields are borrowed from the original report body slice, so the input bytes must outlive this struct.
+///
+/// This struct contains fully typed and parsed fields from the attestation report body.
+/// All fields are parsed to their final types at [`ReportBody::from_bytes`] time, including
+/// TCB version parsing with generation-aware layout selection.
+///
+/// The correct method to generate [`ReportBody`] is from a [`Report`]:
+/// ```ignore
+/// let report = Report::from_bytes(&raw_bytes);
+/// let body = ReportBody::try_from((&report, &vek))
+/// ```
+///
+/// This will verify the signature and body of the report before parsing it into fully typed fields.
+///
+/// [`ReportBody::from_bytes`] can be used to parse the body from raw bytes, but this should be done for debugging purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct AttestationReport {
-    /// Version number of this attestation report. Set to 2h for this specification.
-    pub version: u32,
-    /// The guest SVN.
+pub struct ReportBody<'a> {
+    /// Version number of this attestation report.
+    pub version: ReportVariant,
+
+    /// Guest Security Version Number (SVN).
     pub guest_svn: u32,
-    /// The guest policy.
+
+    /// Guest policy governing hypervisor restrictions.
     pub policy: GuestPolicy,
-    /// The family ID provided at launch.
-    pub family_id: [u8; 16],
-    /// The image ID provided at launch.
-    pub image_id: [u8; 16],
-    /// The request VMPL for the attestation report.
+
+    /// Family ID provided at launch (128 bits).
+    pub family_id: &'a [u8; 16],
+
+    /// Image ID provided at launch (128 bits).
+    pub image_id: &'a [u8; 16],
+
+    /// Virtual Machine Privilege Level (VMPL) of the attestation request.
     pub vmpl: u32,
-    /// The signature algorithm used to sign this report.
+
+    /// Signature algorithm used to sign this report.
     pub sig_algo: u32,
-    /// Current TCB. See SNPTcbVersion
+
+    /// Current TCB (Trusted Computing Base) version, parsed for the inferred generation.
     pub current_tcb: TcbVersion,
-    /// Information about the platform. See PlatformInfo
+
+    /// Platform information flags.
     pub plat_info: PlatformInfo,
-    /// Information related to signing keys in the report. See KeyInfo
+
+    /// Key and signing information.
     pub key_info: KeyInfo,
 
-    /// Guest-provided 512 Bits of Data
-    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
-    pub report_data: [u8; 64],
+    /// Guest-provided data (512 bits).
+    pub report_data: &'a [u8; 64],
 
-    /// The measurement calculated at launch.
-    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
-    pub measurement: [u8; 48],
+    /// Launch measurement (SHA-384).
+    pub measurement: &'a [u8; 48],
 
-    /// Data provided by the hypervisor at launch.
-    pub host_data: [u8; 32],
+    /// Host-provided data (256 bits).
+    pub host_data: &'a [u8; 32],
 
-    /// SHA-384 digest of the ID public key that signed the ID block provided
-    /// in SNP_LANUNCH_FINISH.
-    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
-    pub id_key_digest: [u8; 48],
+    /// SHA-384 digest of the ID public key.
+    pub id_key_digest: &'a [u8; 48],
 
-    /// SHA-384 digest of the Author public key that certified the ID key,
-    /// if provided in SNP_LAUNCH_FINSIH. Zeroes if AUTHOR_KEY_EN is 1.
-    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
-    pub author_key_digest: [u8; 48],
-    /// Report ID of this guest.
-    pub report_id: [u8; 32],
-    /// Report ID of this guest's migration agent (if applicable).
-    pub report_id_ma: [u8; 32],
-    /// Reported TCB version used to derive the VCEK that signed this report.
+    /// SHA-384 digest of the Author public key.
+    pub author_key_digest: &'a [u8; 48],
+
+    /// Report ID of this guest (256 bits).
+    pub report_id: &'a [u8; 32],
+
+    /// Report ID of this guest's migration agent (256 bits).
+    pub report_id_ma: &'a [u8; 32],
+
+    /// Reported TCB version used to derive the VCEK, parsed for the inferred generation.
     pub reported_tcb: TcbVersion,
-    /// CPUID Familiy ID (Combined Extended Family ID and Family ID)
+
+    /// CPUID Family ID - present in report version 3+.
     pub cpuid_fam_id: Option<u8>,
-    /// CPUID Model (Combined Extended Model and Model fields)
+
+    /// CPUID Model ID - present in report version 3+.
     pub cpuid_mod_id: Option<u8>,
-    /// CPUID Stepping
+
+    /// CPUID Stepping - present in report version 3+.
     pub cpuid_step: Option<u8>,
 
-    /// If MaskChipId is set to 0, Identifier unique to the chip.
-    /// Otherwise set to 0h.
-    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
-    pub chip_id: [u8; 64],
-    /// CommittedTCB
+    /// Chip identifier (512 bits). Zero if MaskChipId was set during launch.
+    pub chip_id: &'a [u8; 64],
+
+    /// Committed TCB version, parsed for the inferred generation.
     pub committed_tcb: TcbVersion,
-    /// The build number of CurrentVersion
+
+    /// Current firmware version (major.minor.build).
     pub current: Version,
-    /// The build number of CommittedVersion
+
+    /// Committed firmware version (major.minor.build).
     pub committed: Version,
-    /// The CurrentTcb at the time the guest was launched or imported.
+
+    /// Launch TCB version, parsed for the inferred generation.
     pub launch_tcb: TcbVersion,
-    /// The verified mitigation vecor value at the time the guest was launched (LaunchMitVector).
+
+    /// Launch mitigation vector - present in report version 5+.
     pub launch_mit_vector: Option<u64>,
-    /// Value is set to the current verified mitigation vectore value (CurrentMitVector).
+
+    /// Current mitigation vector - present in report version 5+.
     pub current_mit_vector: Option<u64>,
-    /// Signature of bytes 0 to 0x29F inclusive of this report.
-    /// The format of the signature is found within Signature.
-    pub signature: Signature,
 }
 
-impl Default for AttestationReport {
-    fn default() -> Self {
-        Self {
-            version: Default::default(),
-            guest_svn: Default::default(),
-            policy: Default::default(),
-            family_id: Default::default(),
-            image_id: Default::default(),
-            vmpl: Default::default(),
-            sig_algo: Default::default(),
-            current_tcb: Default::default(),
-            plat_info: Default::default(),
-            key_info: Default::default(),
-            report_data: [0u8; 64],
-            measurement: [0u8; 48],
-            host_data: Default::default(),
-            id_key_digest: [0u8; 48],
-            author_key_digest: [0u8; 48],
-            report_id: Default::default(),
-            report_id_ma: Default::default(),
-            reported_tcb: Default::default(),
-            cpuid_fam_id: Default::default(),
-            cpuid_mod_id: Default::default(),
-            cpuid_step: Default::default(),
-            chip_id: [0u8; 64],
-            committed_tcb: Default::default(),
-            current: Default::default(),
-            committed: Default::default(),
-            launch_tcb: Default::default(),
-            launch_mit_vector: Default::default(),
-            current_mit_vector: Default::default(),
-            signature: Default::default(),
-        }
-    }
-}
+impl<'a> ReportBody<'a> {
+    /// The expected length of the report body (bytes 0x00 to 0x2A0).
+    pub const BODY_LEN: usize = 0x2A0;
 
-impl Encoder<()> for AttestationReport {
-    fn encode(&self, writer: &mut impl Write, _: ()) -> Result<(), std::io::Error> {
-        // Determine the variant based on version and CPUID step
-        let variant = match self.version {
-            2 => ReportVariant::V2,
-            3 | 4 => ReportVariant::V3,
-            _ => ReportVariant::V5,
-        };
-
-        let generation = match variant {
-            ReportVariant::V2 => {
-                if Self::chip_id_is_turin_like(&self.chip_id)? {
-                    Generation::Turin
-                } else {
-                    Generation::Genoa
-                }
-            }
-            _ => {
-                let family = self.cpuid_fam_id.unwrap_or(0);
-                let model = self.cpuid_mod_id.unwrap_or(0);
-                Generation::identify_cpu(family, model)?
-            }
-        };
-
-        // Write version (common to all variants)
-        writer.write_bytes(self.version, ())?;
-        writer.write_bytes(self.guest_svn, ())?;
-        writer.write_bytes(self.policy, ())?;
-        writer.write_bytes(self.family_id, ())?;
-        writer.write_bytes(self.image_id, ())?;
-        writer.write_bytes(self.vmpl, ())?;
-        writer.write_bytes(self.sig_algo, ())?;
-        writer.write_bytes(self.current_tcb, generation)?;
-        writer.write_bytes(self.plat_info, ())?;
-        writer.write_bytes(self.key_info, ())?;
-        writer
-            .skip_bytes::<4>()?
-            .write_bytes(self.report_data, ())?;
-        writer.write_bytes(self.measurement, ())?;
-        writer.write_bytes(self.host_data, ())?;
-        writer.write_bytes(self.id_key_digest, ())?;
-        writer.write_bytes(self.author_key_digest, ())?;
-        writer.write_bytes(self.report_id, ())?;
-        writer.write_bytes(self.report_id_ma, ())?;
-        writer.write_bytes(self.reported_tcb, generation)?;
-
-        // Write CPUID fields based on variant
-        match variant {
-            ReportVariant::V2 => {
-                // V2 doesn't have CPUID fields
-                writer.skip_bytes::<24>()?.write_bytes(self.chip_id, ())?;
-            }
-            _ => {
-                // Write CPUID fields for V3 and V4
-                writer.write_bytes(self.cpuid_fam_id.unwrap_or(0), ())?;
-                writer.write_bytes(self.cpuid_mod_id.unwrap_or(0), ())?;
-                writer.write_bytes(self.cpuid_step.unwrap_or(0), ())?;
-                writer.skip_bytes::<21>()?.write_bytes(self.chip_id, ())?;
-            }
+    /// Parses a raw attestation report body into a typed [`ReportBody`].
+    ///
+    /// Security Warning
+    ///
+    /// This function **does not perform any cryptographic verification**.
+    /// It only parses the provided byte slice according to the SEV-SNP
+    /// attestation report layout.
+    ///
+    /// Calling this method directly means the caller is responsible for
+    /// ensuring that the input bytes are authentic and have not been
+    /// tampered with.
+    ///
+    /// ---
+    ///
+    /// # Correct Usage
+    ///
+    /// The **recommended and correct way** to obtain a [`ReportBody`] is via
+    /// the `TryFrom` implementation that verifies the report signature first:
+    ///
+    /// ```ignore
+    /// let report = Report::from_bytes(&raw_bytes)?;
+    /// let body = ReportBody::try_from((&report, &certificate))?;
+    /// ```
+    ///
+    /// or
+    ///
+    /// ```ignore
+    /// let report = Report::from_bytes(&raw_bytes)?;
+    /// let body = ReportBody::try_from((&report, &chain))?;
+    /// ```
+    ///
+    /// These conversion paths:
+    ///
+    /// 1. Verify the report signature using the provided VEK or certificate chain.
+    /// 2. Only after successful verification, parse the signed body bytes
+    ///    into a typed [`ReportBody`].
+    ///
+    /// This ensures that parsed fields such as TCB versions, policy flags,
+    /// measurements, and identifiers are cryptographically authenticated.
+    ///
+    /// ---
+    ///
+    /// # Intended Use of `from_bytes`
+    ///
+    /// This method exists primarily for:
+    ///
+    /// - Internal parsing after successful verification
+    /// - Debugging and inspection of raw report bytes
+    /// - Unit tests that validate layout and field decoding logic
+    ///
+    /// It should **not** be used in security-sensitive paths where the
+    /// authenticity of the report matters.
+    ///
+    /// ---
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// - The body length is incorrect
+    /// - The report version is unsupported
+    /// - Reserved fields are non-zero
+    /// - The chip ID is masked (for V2 reports)
+    /// - Generation inference fails
+    ///
+    /// This function validates structural correctness, but **not**
+    /// authenticity.
+    ///
+    pub fn from_bytes(body: &'a [u8]) -> Result<Self, std::io::Error> {
+        if body.len() != Self::BODY_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Report body length incorrect: expected {} bytes, got {}",
+                    Self::BODY_LEN,
+                    body.len()
+                ),
+            ));
         }
 
-        // Write committed TCB based on variant
-        writer.write_bytes(self.committed_tcb, generation)?;
-        writer.write_bytes(self.current, ())?;
-        writer.skip_bytes::<1>()?.write_bytes(self.committed, ())?;
-        writer
-            .skip_bytes::<1>()?
-            .write_bytes(self.launch_tcb, generation)?;
+        // Parse version to determine variant and generation
+        let version = ReportVariant::decode(&mut &body[0x00..0x04], ())?;
 
-        // Write launch and current mitigation vectors based on variant
-        match variant {
-            ReportVariant::V2 | ReportVariant::V3 => {
-                writer
-                    .skip_bytes::<168>()?
-                    .write_bytes(self.signature, ())?;
-            }
-            _ => {
-                writer.write_bytes(self.launch_mit_vector.unwrap_or(0), ())?;
-                writer.write_bytes(self.current_mit_vector.unwrap_or(0), ())?;
-                writer
-                    .skip_bytes::<152>()?
-                    .write_bytes(self.signature, ())?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl Decoder<()> for AttestationReport {
-    fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
-        let mut bytes = vec![0u8; ATT_REP_FW_LEN];
-        reader.read_exact(&mut bytes)?;
-
-        let variant = ReportVariant::from_bytes(&bytes[0..4])?;
-
-        let generation = match variant {
-            ReportVariant::V2 => {
-                if Self::chip_id_is_turin_like(&bytes[CHIP_ID_RANGE])? {
-                    Generation::Turin
-                } else {
-                    Generation::Genoa
-                }
-            }
-            _ => {
-                let family = &bytes[CPUID_FAMILY_ID_BYTES];
-                let model = &bytes[CPUID_MODEL_ID_BYTES];
-                Generation::identify_cpu(*family, *model)?
+        // Infer generation from chip_id (V2) or CPUID fields (V3+)
+        let generation = if version >= ReportVariant::V3 {
+            // V3+ uses CPUID fields
+            let family = body[0x188];
+            let model = body[0x189];
+            Generation::identify_cpu(family, model)?
+        } else {
+            // V2 uses chip_id heuristic
+            let chip_id_bytes = &body[0x1A0..0x1E0];
+            if chip_id_bytes == &[0u8; 64][..] {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Chip ID is masked",
+                ));
+            } else if chip_id_bytes[8..] == [0u8; 56] {
+                // Turin-like: first 8 bytes non-zero, rest zero
+                Generation::Turin
+            } else {
+                // Genoa-like: full 64 bytes used
+                Generation::Genoa
             }
         };
 
-        let mut stepper = Cursor::new(&bytes[..]);
+        let guest_svn = u32::decode(&mut &body[0x04..0x08], ())?;
 
-        let version = stepper.read_bytes()?;
-        let guest_svn = stepper.read_bytes()?;
-        let policy = stepper.read_bytes()?;
-        let family_id = stepper.read_bytes()?;
-        let image_id = stepper.read_bytes()?;
-        let vmpl = stepper.read_bytes()?;
-        let sig_algo = stepper.read_bytes()?;
+        let policy = GuestPolicy(u64::decode(&mut &body[0x08..0x10], ())?);
 
-        let current_tcb = stepper.read_bytes_with(generation)?;
-        let plat_info = stepper.read_bytes()?;
-        let key_info = stepper.read_bytes()?;
-        let report_data = stepper.skip_bytes::<4>()?.read_bytes()?;
-        let measurement = stepper.read_bytes()?;
-        let host_data = stepper.read_bytes()?;
-        let id_key_digest = stepper.read_bytes()?;
-        let author_key_digest = stepper.read_bytes()?;
-        let report_id = stepper.read_bytes()?;
-        let report_id_ma = stepper.read_bytes()?;
-        let reported_tcb = stepper.read_bytes_with(generation)?;
+        let family_id: &'a [u8; 16] = <&[u8; 16]>::try_from(&body[0x10..0x20])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
 
-        // CPUID fields were added in V3 and later.
-        let (cpuid_fam_id, cpuid_mod_id, cpuid_step, chip_id) = match variant {
-            ReportVariant::V2 => (None, None, None, stepper.skip_bytes::<24>()?.read_bytes()?),
-            _ => (
-                Some(stepper.read_bytes()?),
-                Some(stepper.read_bytes()?),
-                Some(stepper.read_bytes()?),
-                stepper.skip_bytes::<21>()?.read_bytes()?,
-            ),
+        let image_id: &'a [u8; 16] = <&[u8; 16]>::try_from(&body[0x20..0x30])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let vmpl = u32::decode(&mut &body[0x30..0x34], ())?;
+
+        let sig_algo = u32::decode(&mut &body[0x34..0x38], ())?;
+
+        let current_tcb = TcbVersion::decode(&mut &body[0x38..0x40], generation)?;
+
+        let plat_info = PlatformInfo::decode(&mut &body[0x40..0x48], ())?;
+
+        let key_info = KeyInfo::decode(&mut &body[0x48..0x4C], ())?;
+
+        // Reserved 0x4C - 0x51
+        validate_reserved(&body[0x4C..0x50], 0x4C)?;
+
+        let report_data: &'a [u8; 64] = <&[u8; 64]>::try_from(&body[0x50..0x90])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let measurement: &'a [u8; 48] = <&[u8; 48]>::try_from(&body[0x90..0xC0])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let host_data: &'a [u8; 32] = <&[u8; 32]>::try_from(&body[0xC0..0xE0])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let id_key_digest: &'a [u8; 48] = <&[u8; 48]>::try_from(&body[0xE0..0x110])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let author_key_digest: &'a [u8; 48] = <&[u8; 48]>::try_from(&body[0x110..0x140])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let report_id: &'a [u8; 32] = <&[u8; 32]>::try_from(&body[0x140..0x160])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let report_id_ma: &'a [u8; 32] = <&[u8; 32]>::try_from(&body[0x160..0x180])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
+
+        let reported_tcb = TcbVersion::decode(&mut &body[0x180..0x188], generation)?;
+
+        // Parse CPUID fields (V3+) or extract raw values
+        let (cpuid_fam_id, cpuid_mod_id, cpuid_step) = if version >= ReportVariant::V3 {
+            // Reserved 0x18B - 0x1A0
+            validate_reserved(&body[0x18B..0x1A0], 0x18B)?;
+            (Some(body[0x188]), Some(body[0x189]), Some(body[0x18A]))
+        } else {
+            // Reserved 0x188 - 0x1A0
+            validate_reserved(&body[0x188..0x1A0], 0x188)?;
+            (None, None, None)
         };
 
-        let committed_tcb = stepper.read_bytes_with(generation)?;
-        let current = stepper.read_bytes()?;
-        let committed = stepper.skip_bytes::<1>()?.read_bytes()?;
-        let launch_tcb = stepper.skip_bytes::<1>()?.read_bytes_with(generation)?;
+        let chip_id: &'a [u8; 64] = <&[u8; 64]>::try_from(&body[0x1A0..0x1E0])
+            .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
 
-        // mit vecor fields were added in V5 and later.
-        let (launch_mit_vector, current_mit_vector, signature) = match variant {
-            ReportVariant::V2 | ReportVariant::V3 => {
-                (None, None, stepper.skip_bytes::<168>()?.read_bytes()?)
-            }
-            _ => (
-                Some(stepper.read_bytes()?),
-                Some(stepper.read_bytes()?),
-                stepper.skip_bytes::<152>()?.read_bytes()?,
-            ),
+        let committed_tcb = TcbVersion::decode(&mut &body[0x1E0..0x1E8], generation)?;
+
+        // Parse current and committed firmware versions
+        let current = Version {
+            build: body[0x1E8],
+            minor: body[0x1E9],
+            major: body[0x1EA],
+        };
+
+        // Reserved 0x1EB
+        validate_reserved(&body[0x1EB..0x1EC], 0x1EB)?;
+
+        let committed = Version {
+            build: body[0x1EC],
+            minor: body[0x1ED],
+            major: body[0x1EE],
+        };
+
+        // Reserved 0x1EF
+        validate_reserved(&body[0x1EF..0x1F0], 0x1EF)?;
+
+        let launch_tcb = TcbVersion::decode(&mut &body[0x1F0..0x1F8], generation)?;
+
+        // Parse mitigation vector fields (V5+)
+        let (launch_mit_vector, current_mit_vector) = if version >= ReportVariant::V5 {
+            // Reserved 0x208 - 0x2A0
+            validate_reserved(&body[0x208..0x2A0], 0x208)?;
+            let launch = u64::decode(&mut &body[0x1F8..0x200], ())?;
+            let current = u64::decode(&mut &body[0x200..0x208], ())?;
+            (Some(launch), Some(current))
+        } else {
+            // Reserved 0x1F8 - 0x2A0
+            validate_reserved(&body[0x1F8..0x2A0], 0x1F8)?;
+            (None, None)
         };
 
         Ok(Self {
@@ -545,32 +812,11 @@ impl Decoder<()> for AttestationReport {
             launch_tcb,
             launch_mit_vector,
             current_mit_vector,
-            signature,
         })
     }
 }
 
-impl ByteParser<()> for AttestationReport {
-    type Bytes = [u8; ATT_REP_FW_LEN];
-    const EXPECTED_LEN: Option<usize> = Some(ATT_REP_FW_LEN);
-}
-
-impl AttestationReport {
-    #[inline(always)]
-    /// Checks if the MaskChipId is set to 1. If not, then it will check if
-    /// the CHIP_ID is Turin-like.
-    fn chip_id_is_turin_like(bytes: &[u8]) -> Result<bool, AttestationReportError> {
-        // Chip ID -> 0x1A0-0x1E0
-        if bytes == [0; 64] {
-            return Err(AttestationReportError::MaskedChipId);
-        }
-
-        // Last 8 bytes of CHIP_ID are zero, then it is Turin Like.
-        Ok(bytes[8..] == [0; 56])
-    }
-}
-
-impl Display for AttestationReport {
+impl Display for ReportBody<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -639,25 +885,24 @@ Launch TCB:
 Launch Mitigation Vector:     {}
 
 Current Mitigation Vector:    {}
-
-{}"#,
+"#,
             self.version,
             self.guest_svn,
             self.policy,
-            HexLine(&self.family_id),
-            HexLine(&self.image_id),
+            HexLine(self.family_id),
+            HexLine(self.image_id),
             self.vmpl,
             self.sig_algo,
             self.current_tcb,
             self.plat_info,
             self.key_info,
-            HexLine(&self.report_data),
-            HexLine(&self.measurement),
-            HexLine(&self.host_data),
-            HexLine(&self.id_key_digest),
-            HexLine(&self.author_key_digest),
-            HexLine(&self.report_id),
-            HexLine(&self.report_id_ma),
+            HexLine(self.report_data),
+            HexLine(self.measurement),
+            HexLine(self.host_data),
+            HexLine(self.id_key_digest),
+            HexLine(self.author_key_digest),
+            HexLine(self.report_id),
+            HexLine(self.report_id_ma),
             self.reported_tcb,
             self.cpuid_fam_id
                 .map_or("None".to_string(), |fam| fam.to_string()),
@@ -665,7 +910,7 @@ Current Mitigation Vector:    {}
                 .map_or("None".to_string(), |model| model.to_string()),
             self.cpuid_step
                 .map_or("None".to_string(), |step| step.to_string()),
-            HexLine(&self.chip_id),
+            HexLine(self.chip_id),
             self.committed_tcb,
             self.current,
             self.committed,
@@ -674,124 +919,7 @@ Current Mitigation Vector:    {}
                 .map_or("None".to_string(), |lmv| lmv.to_string()),
             self.current_mit_vector
                 .map_or("None".to_string(), |cmv| cmv.to_string()),
-            self.signature
         )
-    }
-}
-
-#[cfg(feature = "openssl")]
-impl Verifiable for (&Chain, &AttestationReport) {
-    type Output = ();
-
-    fn verify(self) -> std::io::Result<Self::Output> {
-        let vek = self.0.verify()?;
-
-        let sig = EcdsaSig::try_from(&self.1.signature)?;
-
-        let raw_report_bytes = self.1.to_bytes()?;
-
-        let measurable_bytes: &[u8] = &raw_report_bytes[..0x2a0];
-
-        let mut hasher = Sha384::new();
-        hasher.update(measurable_bytes);
-        let base_digest = hasher.finish();
-
-        let ec = vek.public_key()?.ec_key()?;
-        let signed = sig.verify(&base_digest, &ec)?;
-        match signed {
-            true => Ok(()),
-            false => Err(Error::other("VEK does not sign the attestation report")),
-        }
-    }
-}
-
-#[cfg(feature = "openssl")]
-impl Verifiable for (&Certificate, &AttestationReport) {
-    type Output = ();
-
-    fn verify(self) -> std::io::Result<Self::Output> {
-        let vek = self.0;
-
-        let sig = EcdsaSig::try_from(&self.1.signature)?;
-        let raw_report_bytes = self.1.to_bytes()?;
-
-        let measurable_bytes: &[u8] = &raw_report_bytes[..0x2a0];
-
-        let mut hasher = Sha384::new();
-        hasher.update(measurable_bytes);
-        let base_digest = hasher.finish();
-
-        let ec = vek.public_key()?.ec_key()?;
-        let signed = sig.verify(&base_digest, &ec)?;
-        match signed {
-            true => Ok(()),
-            false => Err(Error::other("VEK does not sign the attestation report")),
-        }
-    }
-}
-
-#[cfg(feature = "crypto_nossl")]
-impl Verifiable for (&Chain, &AttestationReport) {
-    type Output = ();
-
-    fn verify(self) -> std::io::Result<Self::Output> {
-        // According to Chapter 3 of the Versioned Chip Endorsement Key (VCEK) Certificate and the Versioned Loaded Endorsement Key (VLEK)
-        // Certificate specifications, both Versioned Endorsement Key certificates certify an ECDSA public key on curve P-384,
-        // with the signature hash algorithm being SHA-384.
-
-        let vek = self.0.verify()?;
-
-        let sig = p384::ecdsa::Signature::try_from(&self.1.signature)?;
-
-        let raw_report_bytes = self.1.to_bytes()?;
-
-        let measurable_bytes: &[u8] = &raw_report_bytes[..0x2a0];
-
-        use sha2::Digest;
-        let base_digest = sha2::Sha384::new_with_prefix(measurable_bytes);
-        let verifying_key = p384::ecdsa::VerifyingKey::from_sec1_bytes(vek.public_key_sec1())
-            .map_err(|e| {
-                std::io::Error::other(format!(
-                    "failed to deserialize public key from sec1 bytes: {e:?}"
-                ))
-            })?;
-        use p384::ecdsa::signature::DigestVerifier;
-        verifying_key.verify_digest(base_digest, &sig).map_err(|e| {
-            std::io::Error::other(format!("VEK does not sign the attestation report: {e:?}"))
-        })
-    }
-}
-
-#[cfg(feature = "crypto_nossl")]
-impl Verifiable for (&Certificate, &AttestationReport) {
-    type Output = ();
-
-    fn verify(self) -> std::io::Result<Self::Output> {
-        // According to Chapter 3 of the [Versioned Chip Endorsement Key (VCEK) Certificate and
-        // KDS Interface Specification][spec], the VCEK certificate certifies an ECDSA public key on curve P-384,
-        // and the signature hash algorithm is sha384.
-        // [spec]: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/57230.pdf
-
-        let vek = self.0;
-
-        let sig = p384::ecdsa::Signature::try_from(&self.1.signature)?;
-
-        let raw_report_bytes = self.1.to_bytes()?;
-
-        let measurable_bytes: &[u8] = &raw_report_bytes[..0x2a0];
-
-        use sha2::Digest;
-        let base_digest = sha2::Sha384::new_with_prefix(measurable_bytes);
-        let verifying_key = p384::ecdsa::VerifyingKey::from_sec1_bytes(vek.public_key_sec1())
-            .map_err(|e| {
-                std::io::Error::other(format!(
-                    "failed to deserialize public key from sec1 bytes: {e:?}"
-                ))
-            })?;
-        use p384::ecdsa::signature::DigestVerifier;
-        verifying_key.verify_digest(base_digest, &sig).map_err(|e| {
-            std::io::Error::other(format!("VEK does not sign the attestation report: {e:?}"))
-        })
     }
 }
 
@@ -850,6 +978,8 @@ bitfield! {
     /// option is selected to disable these Page Move commands, then these commands will return POLICY_FAILURE.
     /// 0: Do not disable Guest support for the commands.
     /// 1: Disable Guest support for the commands.
+    ///
+    /// **Since:** Report v5+
     pub page_swap_disabled, set_page_swap_disabled: 25;
 }
 
@@ -1097,8 +1227,10 @@ impl Display for KeyInfo {
 #[cfg(test)]
 mod tests {
 
+    use std::ops::Range;
+
     use super::*;
-    use std::{convert::TryInto, io::Write};
+    const CHIP_ID_RANGE: Range<usize> = 0x1A0..0x1E0;
 
     #[test]
     fn test_derive_key_new() {
@@ -1162,10 +1294,22 @@ mod tests {
     }
 
     #[test]
-    fn test_attestation_report_fmt() {
+    fn test_report_body_fmt_v2_zero() {
+        // Build a full firmware report (1184) with v2 and a non-masked chip_id.
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+
+        // version: u32 LE at 0x00..0x04
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes());
+
+        // Make chip_id non-zero so v2 parsing doesn't error out
+        bytes[CHIP_ID_RANGE.start] = 1;
+
+        let report = Report::from_bytes(&bytes).unwrap();
+        let body = ReportBody::from_bytes(report.body).unwrap();
+
         let expected: &str = r#"Attestation Report:
 
-Version:                      0
+Version:                      V2
 
 Guest SVN:                    0
 
@@ -1199,7 +1343,7 @@ TCB Version:
   SNP:         0
   TEE:         0
   Boot Loader: 0
-  FMC:         None
+  FMC:         0
 
 Platform Info (0):
   SMT Enabled:               false
@@ -1255,7 +1399,7 @@ TCB Version:
   SNP:         0
   TEE:         0
   Boot Loader: 0
-  FMC:         None
+  FMC:         0
 
 CPUID Family ID:              None
 
@@ -1264,7 +1408,7 @@ CPUID Model ID:               None
 CPUID Stepping:               None
 
 Chip ID:
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -1276,7 +1420,7 @@ TCB Version:
   SNP:         0
   TEE:         0
   Boot Loader: 0
-  FMC:         None
+  FMC:         0
 
 Current Version:              0.0.0
 
@@ -1289,35 +1433,26 @@ TCB Version:
   SNP:         0
   TEE:         0
   Boot Loader: 0
-  FMC:         None
+  FMC:         0
 
 Launch Mitigation Vector:     None
 
 Current Mitigation Vector:    None
+"#;
 
-Signature:
-  R:
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00
-  S:
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00"#;
-        assert_eq!(expected, AttestationReport::default().to_string())
+        assert_eq!(expected, body.to_string());
     }
 
     #[test]
-    fn test_attestation_report_copy() {
-        let expected: AttestationReport = AttestationReport::default();
+    fn test_report_copy() {
+        let bytes = vec![0u8; Report::REPORT_LEN];
+        let report = Report::from_bytes(&bytes).unwrap();
+        let copy = report;
 
-        let copy: AttestationReport = expected;
-
-        assert_eq!(expected, copy);
+        assert_eq!(report.body.as_ptr(), copy.body.as_ptr());
+        assert_eq!(report.body.len(), copy.body.len());
+        assert_eq!(report.signature.as_ptr(), copy.signature.as_ptr());
+        assert_eq!(report.signature.len(), copy.signature.len());
     }
 
     #[test]
@@ -1624,17 +1759,30 @@ Signature:
     }
 
     #[test]
-    fn test_attestation_report_fields() {
-        let report: AttestationReport = AttestationReport {
-            version: 2,
-            guest_svn: 1,
-            vmpl: 3,
-            ..Default::default()
-        };
-        assert_eq!(report.version, 2);
-        assert_eq!(report.guest_svn, 1);
-        assert_eq!(report.vmpl, 3);
-        assert_eq!(report.measurement, [0; 48]);
+    fn test_report_body_selected_fields() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+
+        // v2: version u32 LE at 0x00..0x04
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes());
+
+        // v2 requires chip_id not fully masked (not all zeros)
+        bytes[CHIP_ID_RANGE.start] = 1;
+
+        // guest_svn at 0x04..0x08
+        bytes[0x04..0x08].copy_from_slice(&1u32.to_le_bytes());
+
+        // vmpl at 0x30..0x34
+        bytes[0x30..0x34].copy_from_slice(&3u32.to_le_bytes());
+
+        let report = Report::from_bytes(&bytes).unwrap();
+
+        // NOTE: parsing-only test: do NOT use TryFrom/verify path here
+        let body = ReportBody::from_bytes(report.body).unwrap();
+
+        assert_eq!(body.version, ReportVariant::V2);
+        assert_eq!(body.guest_svn, 1);
+        assert_eq!(body.vmpl, 3);
+        assert_eq!(body.measurement, &[0u8; 48]);
     }
 
     #[test]
@@ -1690,79 +1838,45 @@ Signature:
     }
 
     #[test]
-    fn test_attestation_report_from_bytes() {
-        // Create a valid attestation report bytes minus one byte.
-        let mut bytes: Vec<u8> = vec![0; 1183];
+    fn test_report_from_bytes_ok() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
+        bytes[CHIP_ID_RANGE.start] = 1; // unmask chip id
 
-        // Push the version byte at the beginning.
-        bytes.insert(0, 2);
+        let report = Report::from_bytes(bytes.as_slice());
+        assert!(report.is_ok());
 
-        let vcek = [
-            0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x0F, 0xE6, 0xB1, 0x43, 0xBC, 0xF0,
-            0x40, 0x5B, 0xD7, 0xAE, 0x30, 0x47, 0x27, 0xED, 0xF4, 0x66, 0x03, 0xF2, 0xA7, 0x6A,
-            0xEF, 0x6A, 0x3A, 0xBC, 0x15, 0xD7, 0xAF, 0x38, 0xDB, 0x75, 0x70, 0x39, 0x02, 0x9F,
-            0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
-            0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
-        ];
-
-        bytes[0x1A8..0x1E0].copy_from_slice(&vcek[..(0x1E0 - 0x1A8)]);
-
-        // Test valid input
-        let result = AttestationReport::from_bytes(bytes.as_slice());
-        assert!(result.is_ok());
+        // Also ensure the body can be parsed
+        let report = report.unwrap();
+        assert!(ReportBody::from_bytes(report.body).is_ok());
     }
 
     #[test]
-    #[should_panic]
-    fn test_attestation_report_from_invalid_bytes() {
-        // Create a valid attestation report bytes minus one byte.
-        let mut bytes: Vec<u8> = vec![0; 1183];
-
-        // Push the version byte at the beginning.
-        bytes.insert(0, 2);
-
-        // Test invalid input (too short)
-        AttestationReport::from_bytes(bytes[..100].try_into().unwrap()).unwrap();
+    fn test_report_from_bytes_rejects_bad_len() {
+        let bytes = vec![0u8; Report::REPORT_LEN - 1];
+        let err = Report::from_bytes(&bytes).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]
-    fn test_attestation_report_parse_and_write_bytes() {
-        let report = AttestationReport {
-            version: 2,
-            guest_svn: Default::default(),
-            policy: Default::default(),
-            family_id: Default::default(),
-            image_id: Default::default(),
-            chip_id: [
-                0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x0F, 0xE6, 0xB1, 0x43, 0xBC, 0xF0,
-                0x40, 0x5B, 0xD7, 0xAE, 0x30, 0x47, 0x27, 0xED, 0xF4, 0x66, 0x03, 0xF2, 0xA7, 0x6A,
-                0xEF, 0x6A, 0x3A, 0xBC, 0x15, 0xD7, 0xAF, 0x38, 0xDB, 0x75, 0x70, 0x39, 0x02, 0x9F,
-                0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
-                0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
-            ],
-            ..Default::default()
-        };
+    fn test_report_body_parse_roundtrip_like() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
+        bytes[CHIP_ID_RANGE.start] = 1; // unmask
 
-        // Test successful write
-        let result = report.to_bytes();
-        assert!(result.is_ok());
+        // family_id and image_id
+        bytes[0x10..0x20].copy_from_slice(&[0xAA; 16]);
+        bytes[0x20..0x30].copy_from_slice(&[0xBB; 16]);
 
-        // Test writing to a failing writer
-        struct FailingWriter;
-        impl Write for FailingWriter {
-            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
-                Err(std::io::Error::other("test error"))
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
+        // guest_svn
+        bytes[0x04..0x08].copy_from_slice(&1u32.to_le_bytes());
 
-        let mut writer = FailingWriter;
+        let report = Report::from_bytes(&bytes).unwrap();
+        let body = ReportBody::from_bytes(report.body).unwrap();
 
-        let result = report.encode(&mut FailingWriter, ());
-        assert!(result.is_err());
-        assert!(writer.flush().is_ok());
+        assert_eq!(body.family_id, &[0xAA; 16]);
+        assert_eq!(body.image_id, &[0xBB; 16]);
+        assert_eq!(body.guest_svn, 1);
     }
 
     #[test]
@@ -1800,80 +1914,6 @@ Signature:
 
         assert_eq!(original, cloned);
         assert_eq!(original.to_bytes().unwrap(), cloned.to_bytes().unwrap());
-    }
-
-    #[test]
-    fn test_attestation_report_complex_write() {
-        let report = AttestationReport {
-            version: 2,
-            guest_svn: 1,
-            policy: GuestPolicy::from(0xFF),
-            family_id: [0xAA; 16],
-            image_id: [0xBB; 16],
-            chip_id: [
-                0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x0F, 0xE6, 0xB1, 0x43, 0xBC, 0xF0,
-                0x40, 0x5B, 0xD7, 0xAE, 0x30, 0x47, 0x27, 0xED, 0xF4, 0x66, 0x03, 0xF2, 0xA7, 0x6A,
-                0xEF, 0x6A, 0x3A, 0xBC, 0x15, 0xD7, 0xAF, 0x38, 0xDB, 0x75, 0x70, 0x39, 0x02, 0x9F,
-                0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
-                0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
-            ],
-            ..Default::default()
-        };
-
-        let buffer = report.to_bytes();
-        assert!(buffer.is_ok());
-
-        // Read back and verify
-        let read_back = AttestationReport::from_bytes(&buffer.unwrap()).unwrap();
-        assert_eq!(read_back.version, 2);
-        assert_eq!(read_back.guest_svn, 1);
-        assert_eq!(read_back.family_id, [0xAA; 16]);
-        assert_eq!(read_back.image_id, [0xBB; 16]);
-    }
-
-    #[test]
-    fn test_write_with_limited_writer() {
-        let report = AttestationReport {
-            version: 2,
-            guest_svn: Default::default(),
-            policy: Default::default(),
-            family_id: Default::default(),
-            image_id: Default::default(),
-            chip_id: [
-                0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x0F, 0xE6, 0xB1, 0x43, 0xBC, 0xF0,
-                0x40, 0x5B, 0xD7, 0xAE, 0x30, 0x47, 0x27, 0xED, 0xF4, 0x66, 0x03, 0xF2, 0xA7, 0x6A,
-                0xEF, 0x6A, 0x3A, 0xBC, 0x15, 0xD7, 0xAF, 0x38, 0xDB, 0x75, 0x70, 0x39, 0x02, 0x9F,
-                0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
-                0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
-            ],
-            ..Default::default()
-        };
-
-        // Writer that can only write small chunks
-        struct LimitedWriter {
-            data: Vec<u8>,
-            max_write: usize,
-        }
-
-        impl Write for LimitedWriter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                let write_size = std::cmp::min(self.max_write, buf.len());
-                self.data.extend_from_slice(&buf[..write_size]);
-                Ok(write_size)
-            }
-
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-
-        let mut writer = LimitedWriter {
-            data: Vec::new(),
-            max_write: 16, // Only write 16 bytes at a time
-        };
-
-        assert!(report.encode(&mut writer, ()).is_ok());
-        assert!(writer.flush().is_ok());
     }
 
     #[test]
@@ -1937,8 +1977,11 @@ Signature:
     }
 
     #[test]
-    fn test_turin_like_chip_id_milan_chip_id() {
-        // Valid Milan CHIP_ID
+    fn test_chip_id_v2_genoa_like_allowed() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
+
+        // Genoa-like: full 64 bytes used (i.e., not "first 8 nonzero then rest zero")
         let vcek_bytes = [
             0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x0F, 0xE6, 0xB1, 0x43, 0xBC, 0xF0,
             0x40, 0x5B, 0xD7, 0xAE, 0x30, 0x47, 0x27, 0xED, 0xF4, 0x66, 0x03, 0xF2, 0xA7, 0x6A,
@@ -1946,21 +1989,79 @@ Signature:
             0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
             0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
         ];
+        bytes[CHIP_ID_RANGE.clone()].copy_from_slice(&vcek_bytes);
 
-        assert!(!AttestationReport::chip_id_is_turin_like(&vcek_bytes).unwrap());
+        let report = Report::from_bytes(&bytes).unwrap();
+        let body = ReportBody::from_bytes(report.body).unwrap();
+
+        // Should have cpuid fields absent in v2
+        assert_eq!(body.cpuid_fam_id, None);
+        assert_eq!(body.cpuid_mod_id, None);
+        assert_eq!(body.cpuid_step, None);
+
+        // Should preserve chip_id bytes
+        assert_eq!(body.chip_id, &vcek_bytes);
     }
 
     #[test]
-    fn test_turin_like_chip_id_turin_chip_id() {
-        // Valid Turin CHIP_ID
-        let vcek_bytes = [
-            0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        ];
+    fn test_chip_id_v2_turin_like_allowed() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
 
-        assert!(AttestationReport::chip_id_is_turin_like(&vcek_bytes).unwrap());
+        let mut chip = [0u8; 64];
+        chip[0..8].copy_from_slice(&[0xD4, 0x95, 0x54, 0xEC, 0x71, 0x7F, 0x4E, 0x5B]);
+        // rest remains zero
+        bytes[CHIP_ID_RANGE.clone()].copy_from_slice(&chip);
+
+        let report = Report::from_bytes(&bytes).unwrap();
+        let body = ReportBody::from_bytes(report.body).unwrap();
+
+        assert_eq!(body.chip_id, &chip);
+    }
+
+    #[test]
+    fn test_chip_id_v2_masked_rejected() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
+                                                                // chip_id left as all zeros
+
+        let report = Report::from_bytes(&bytes).unwrap();
+        let err = ReportBody::from_bytes(report.body).unwrap_err();
+        assert!(err.to_string().contains("Chip ID is masked"));
+    }
+
+    #[test]
+    fn test_report_from_bytes_splits_body_and_signature() {
+        let bytes = vec![0u8; Report::REPORT_LEN];
+        let r = Report::from_bytes(&bytes).unwrap();
+
+        assert_eq!(r.body.len(), 0x2a0);
+        assert_eq!(r.signature.len(), 0x49f - 0x2a0);
+        assert_eq!(r.body.as_ptr(), bytes.as_ptr());
+        assert_eq!(
+            r.signature.as_ptr() as usize - bytes.as_ptr() as usize,
+            0x2a0
+        );
+    }
+
+    #[test]
+    fn test_report_variant_tryfrom() {
+        assert_eq!(ReportVariant::try_from(2).unwrap(), ReportVariant::V2);
+        assert_eq!(ReportVariant::try_from(3).unwrap(), ReportVariant::V3);
+        assert_eq!(ReportVariant::try_from(4).unwrap(), ReportVariant::V3);
+        assert_eq!(ReportVariant::try_from(5).unwrap(), ReportVariant::V5);
+        assert!(ReportVariant::try_from(99).is_err());
+    }
+
+    #[test]
+    fn test_report_body_rejects_nonzero_reserved_0x4c() {
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+        bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes());
+        bytes[CHIP_ID_RANGE.start] = 1;
+
+        bytes[0x4C] = 1; // reserved byte non-zero
+
+        let r = Report::from_bytes(&bytes).unwrap();
+        assert!(ReportBody::from_bytes(r.body).is_err());
     }
 }

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -624,6 +624,13 @@ impl<'a> ReportBody<'a> {
         // Parse version to determine variant and generation
         let version = ReportVariant::decode(&mut &body[0x00..0x04], ())?;
 
+        // Parse firmware version early (needed for policy validation)
+        let current = Version {
+            build: body[0x1E8],
+            minor: body[0x1E9],
+            major: body[0x1EA],
+        };
+
         // Infer generation from chip_id (V2) or CPUID fields (V3+)
         let generation = if version >= ReportVariant::V3 {
             // V3+ uses CPUID fields
@@ -649,7 +656,7 @@ impl<'a> ReportBody<'a> {
 
         let guest_svn = u32::decode(&mut &body[0x04..0x08], ())?;
 
-        let policy = GuestPolicy(u64::decode(&mut &body[0x08..0x10], ())?);
+        let policy = GuestPolicy::decode(&mut &body[0x08..0x10], current)?;
 
         let family_id: &'a [u8; 16] = <&[u8; 16]>::try_from(&body[0x10..0x20])
             .map_err(|e| std::io::Error::other(format!("Failed TryFrom Operation: {e}")))?;
@@ -663,11 +670,11 @@ impl<'a> ReportBody<'a> {
 
         let current_tcb = TcbVersion::decode(&mut &body[0x38..0x40], generation)?;
 
-        let plat_info = PlatformInfo::decode(&mut &body[0x40..0x48], ())?;
+        let plat_info = PlatformInfo::decode(&mut &body[0x40..0x48], current)?;
 
-        let key_info = KeyInfo::decode(&mut &body[0x48..0x4C], ())?;
+        let key_info = KeyInfo::decode(&mut &body[0x48..0x4C], current)?;
 
-        // Reserved 0x4C - 0x51
+        // Reserved 0x4C - 0x50
         validate_reserved(&body[0x4C..0x50], 0x4C)?;
 
         let report_data: &'a [u8; 64] = <&[u8; 64]>::try_from(&body[0x50..0x90])
@@ -709,16 +716,12 @@ impl<'a> ReportBody<'a> {
 
         let committed_tcb = TcbVersion::decode(&mut &body[0x1E0..0x1E8], generation)?;
 
-        // Parse current and committed firmware versions
-        let current = Version {
-            build: body[0x1E8],
-            minor: body[0x1E9],
-            major: body[0x1EA],
-        };
+        // current firmware version already parsed earlier for policy validation
 
         // Reserved 0x1EB
         validate_reserved(&body[0x1EB..0x1EC], 0x1EB)?;
 
+        // Parse committed firmware version
         let committed = Version {
             build: body[0x1EC],
             minor: body[0x1ED],
@@ -848,14 +851,14 @@ Current Mitigation Vector:    {}
 "#,
             self.version,
             self.guest_svn,
-            self.policy,
+            self.policy.display_for_version(self.current),
             HexLine(self.family_id),
             HexLine(self.image_id),
             self.vmpl,
             self.sig_algo,
             self.current_tcb,
-            self.plat_info,
-            self.key_info,
+            self.plat_info.display_for_version(self.current),
+            self.key_info.display_for_version(self.current),
             HexLine(self.report_data),
             HexLine(self.measurement),
             HexLine(self.host_data),
@@ -943,6 +946,176 @@ bitfield! {
     pub page_swap_disabled, set_page_swap_disabled: 25;
 }
 
+impl GuestPolicy {
+    const RMB1_BIT_17: u64 = 1u64 << 17;
+    const RESERVED_MBZ_MASK_26_63: u64 = (!0u64) << 26; // bits 26..63
+
+    // Bit 21: CXL_ALLOW (added in v1.55)
+    const CXL_ALLOW_BIT_21: u64 = 1u64 << 21;
+    // Bit 22: MEM_AES_256_XTS (added in v1.55)
+    const MEM_AES_256_XTS_BIT_22: u64 = 1u64 << 22;
+    // Bit 23: RAPL_DIS (added in v1.55)
+    const RAPL_DIS_BIT_23: u64 = 1u64 << 23;
+    // Bit 24: CIPHERTEXT_HIDING (added in v1.55)
+    const CIPHERTEXT_HIDING_BIT_24: u64 = 1u64 << 24;
+    // Bit 25: PAGE_SWAP_DISABLE (added in v1.58)
+    const PAGE_SWAP_DISABLE_BIT_25: u64 = 1u64 << 25;
+
+    // Version 1.55: Added CXL, AES-256-XTS, RAPL, CIPHERTEXT_HIDING (bits 21-24)
+    const VERSION_1_55: Version = Version {
+        major: 1,
+        minor: 55,
+        build: 0,
+    };
+    // Version 1.58: Added PAGE_SWAP_DISABLE (bit 25)
+    const VERSION_1_58: Version = Version {
+        major: 1,
+        minor: 58,
+        build: 0,
+    };
+
+    fn validate_reserved_bits(self, version: Version) -> std::io::Result<()> {
+        let raw = self.0;
+
+        // bit 17 must be 1 (RMB1)
+        if (raw & Self::RMB1_BIT_17) == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("GuestPolicy bit 17 must be 1 (raw=0x{raw:016x})"),
+            ));
+        }
+
+        // bits 26..63 must be zero (MBZ)
+        if (raw & Self::RESERVED_MBZ_MASK_26_63) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("GuestPolicy reserved bits 26..63 must be zero (raw=0x{raw:016x})"),
+            ));
+        }
+
+        // bit 21 (CXL_ALLOW) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::CXL_ALLOW_BIT_21) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "GuestPolicy bit 21 (CXL_ALLOW) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // bit 22 (MEM_AES_256_XTS) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::MEM_AES_256_XTS_BIT_22) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "GuestPolicy bit 22 (MEM_AES_256_XTS) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // bit 23 (RAPL_DIS) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::RAPL_DIS_BIT_23) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "GuestPolicy bit 23 (RAPL_DIS) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // bit 24 (CIPHERTEXT_HIDING) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::CIPHERTEXT_HIDING_BIT_24) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "GuestPolicy bit 24 (CIPHERTEXT_HIDING) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // bit 25 (PAGE_SWAP_DISABLE) is only defined for firmware v1.58+
+        if version < Self::VERSION_1_58 && (raw & Self::PAGE_SWAP_DISABLE_BIT_25) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "GuestPolicy bit 25 (PAGE_SWAP_DISABLE) is only valid for firmware v1.58+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Formats the guest policy with version-aware display.
+    ///
+    /// Policy bits that are not defined for the given firmware version
+    /// will be displayed as "None" instead of their actual value.
+    ///
+    /// # Arguments
+    /// * `version` - The firmware version to use for determining which bits are valid
+    ///
+    /// # Returns
+    /// A formatted string representation of the guest policy
+    pub fn display_for_version(&self, version: Version) -> String {
+        let cxl_allowed = if version >= Self::VERSION_1_55 {
+            format!("{}", self.cxl_allowed())
+        } else {
+            "None".to_string()
+        };
+
+        let mem_aes_256_xts = if version >= Self::VERSION_1_55 {
+            format!("{}", self.mem_aes_256_xts())
+        } else {
+            "None".to_string()
+        };
+
+        let rapl_dis = if version >= Self::VERSION_1_55 {
+            format!("{}", self.rapl_dis())
+        } else {
+            "None".to_string()
+        };
+
+        let ciphertext_hiding = if version >= Self::VERSION_1_55 {
+            format!("{}", self.ciphertext_hiding())
+        } else {
+            "None".to_string()
+        };
+
+        let page_swap_disabled = if version >= Self::VERSION_1_58 {
+            format!("{}", self.page_swap_disabled())
+        } else {
+            "None".to_string()
+        };
+
+        format!(
+            r#"Guest Policy (0x{:x}):
+  ABI Major:         {}
+  ABI Minor:         {}
+  SMT Allowed:       {}
+  Migrate MA:        {}
+  Debug Allowed:     {}
+  Single Socket:     {}
+  CXL Allowed:       {}
+  AES 256 XTS:       {}
+  RAPL Disabled:     {}
+  Ciphertext Hiding: {}
+  Page Swap Disable: {}"#,
+            self.0,
+            self.abi_major(),
+            self.abi_minor(),
+            self.smt_allowed(),
+            self.migrate_ma_allowed(),
+            self.debug_allowed(),
+            self.single_socket_required(),
+            cxl_allowed,
+            mem_aes_256_xts,
+            rapl_dis,
+            ciphertext_hiding,
+            page_swap_disabled
+        )
+    }
+}
+
 impl Encoder<()> for GuestPolicy {
     fn encode(&self, writer: &mut impl Write, _: ()) -> Result<(), std::io::Error> {
         writer.write_bytes(self.0, ())?;
@@ -950,6 +1123,8 @@ impl Encoder<()> for GuestPolicy {
     }
 }
 
+// No checking in case policy is being parsed outside attestation report (e.g. id-block)
+// Assumes latest version for all bits, since older firmware should ignore unknown bits and newer firmware should require reserved bits to be set to 1
 impl Decoder<()> for GuestPolicy {
     fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
         let policy = reader.read_bytes()?;
@@ -957,7 +1132,17 @@ impl Decoder<()> for GuestPolicy {
     }
 }
 
-impl ByteParser<()> for GuestPolicy {
+// Checking reserved bytes according to known reserved bytes in attestation report
+impl Decoder<Version> for GuestPolicy {
+    fn decode(reader: &mut impl Read, version: Version) -> Result<Self, std::io::Error> {
+        let raw: u64 = reader.read_bytes()?;
+        let policy = GuestPolicy(raw);
+        policy.validate_reserved_bits(version)?;
+        Ok(policy)
+    }
+}
+
+impl ByteParser<Version> for GuestPolicy {
     type Bytes = [u8; 8];
     const EXPECTED_LEN: Option<usize> = Some(8);
 }
@@ -1046,6 +1231,172 @@ bitfield! {
 
 }
 
+impl PlatformInfo {
+    // Bit 2: ECC_ENABLED (added in v1.55)
+    const ECC_BIT_2: u64 = 1u64 << 2;
+    // Bit 3: RAPL_DISABLED (added in v1.55)
+    const RAPL_BIT_3: u64 = 1u64 << 3;
+    // Bit 4: CIPHERTEXT_HIDING_ENABLED (added in v1.55)
+    const CIPHERTEXT_HIDING_BIT_4: u64 = 1u64 << 4;
+    // Bit 5: ALIAS_CHECK_COMPLETE (added in v1.57)
+    const ALIAS_CHECK_BIT_5: u64 = 1u64 << 5;
+    // Bit 6: Reserved (always MBZ)
+    const RESERVED_BIT_6: u64 = 1u64 << 6;
+    // Bit 7: TIO_ENABLED (added in v1.56)
+    const TIO_BIT_7: u64 = 1u64 << 7;
+    // Bits 8-63: Reserved (always MBZ)
+    const RESERVED_BITS_8_63: u64 = (!0u64) << 8;
+
+    // Version constants
+    const VERSION_1_55: Version = Version {
+        major: 1,
+        minor: 55,
+        build: 0,
+    };
+    const VERSION_1_56: Version = Version {
+        major: 1,
+        minor: 56,
+        build: 0,
+    };
+    const VERSION_1_57: Version = Version {
+        major: 1,
+        minor: 57,
+        build: 0,
+    };
+
+    fn validate_reserved_bits(self, version: Version) -> std::io::Result<()> {
+        let raw = self.0;
+
+        // Bit 6 and bits 8-63 are always reserved
+        if (raw & Self::RESERVED_BIT_6) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("PlatformInfo bit 6 is reserved and must be zero (raw=0x{raw:016x})"),
+            ));
+        }
+
+        if (raw & Self::RESERVED_BITS_8_63) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("PlatformInfo bits 8-63 are reserved and must be zero (raw=0x{raw:016x})"),
+            ));
+        }
+
+        // Bit 2 (ECC_ENABLED) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::ECC_BIT_2) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "PlatformInfo bit 2 (ECC_ENABLED) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // Bit 3 (RAPL_DISABLED) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::RAPL_BIT_3) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "PlatformInfo bit 3 (RAPL_DISABLED) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // Bit 4 (CIPHERTEXT_HIDING_ENABLED) is only defined for firmware v1.55+
+        if version < Self::VERSION_1_55 && (raw & Self::CIPHERTEXT_HIDING_BIT_4) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "PlatformInfo bit 4 (CIPHERTEXT_HIDING_ENABLED) is only valid for firmware v1.55+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // Bit 5 (ALIAS_CHECK_COMPLETE) is only defined for firmware v1.57+
+        if version < Self::VERSION_1_57 && (raw & Self::ALIAS_CHECK_BIT_5) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "PlatformInfo bit 5 (ALIAS_CHECK_COMPLETE) is only valid for firmware v1.57+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        // Bit 7 (TIO_ENABLED) is only defined for firmware v1.56+
+        if version < Self::VERSION_1_56 && (raw & Self::TIO_BIT_7) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "PlatformInfo bit 7 (TIO_ENABLED) is only valid for firmware v1.56+ (raw=0x{raw:016x})"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Formats the platform info with version-aware display.
+    ///
+    /// Platform info bits that are not defined for the given firmware version
+    /// will be displayed as "None" instead of their actual value.
+    ///
+    /// # Arguments
+    /// * `version` - The firmware version to use for determining which bits are valid
+    ///
+    /// # Returns
+    /// A formatted string representation of the platform info
+    pub fn display_for_version(&self, version: Version) -> String {
+        let ecc_enabled = if version >= Self::VERSION_1_55 {
+            format!("{}", self.ecc_enabled())
+        } else {
+            "None".to_string()
+        };
+
+        let rapl_disabled = if version >= Self::VERSION_1_55 {
+            format!("{}", self.rapl_disabled())
+        } else {
+            "None".to_string()
+        };
+
+        let ciphertext_hiding_enabled = if version >= Self::VERSION_1_55 {
+            format!("{}", self.ciphertext_hiding_enabled())
+        } else {
+            "None".to_string()
+        };
+
+        let alias_check_complete = if version >= Self::VERSION_1_57 {
+            format!("{}", self.alias_check_complete())
+        } else {
+            "None".to_string()
+        };
+
+        let tio_enabled = if version >= Self::VERSION_1_56 {
+            format!("{}", self.tio_enabled())
+        } else {
+            "None".to_string()
+        };
+
+        format!(
+            r#"Platform Info ({}):
+  SMT Enabled:               {}
+  TSME Enabled:              {}
+  ECC Enabled:               {}
+  RAPL Disabled:             {}
+  Ciphertext Hiding Enabled: {}
+  Alias Check Complete:      {}
+  SEV-TIO Enabled:           {}"#,
+            self.0,
+            self.smt_enabled(),
+            self.tsme_enabled(),
+            ecc_enabled,
+            rapl_disabled,
+            ciphertext_hiding_enabled,
+            alias_check_complete,
+            tio_enabled
+        )
+    }
+}
+
 impl Display for PlatformInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -1089,14 +1440,30 @@ impl Encoder<()> for PlatformInfo {
     }
 }
 
+// No checking in case platform info is being parsed outside attestation report
 impl Decoder<()> for PlatformInfo {
     fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
-        let info = reader.read_bytes()?;
-        Ok(Self(info))
+        let raw: u64 = reader.read_bytes()?;
+        Ok(PlatformInfo(raw))
+    }
+}
+
+// Checking reserved bytes according to known reserved bytes in attestation report
+impl Decoder<Version> for PlatformInfo {
+    fn decode(reader: &mut impl Read, version: Version) -> Result<Self, std::io::Error> {
+        let raw: u64 = reader.read_bytes()?;
+        let info = PlatformInfo(raw);
+        info.validate_reserved_bits(version)?;
+        Ok(info)
     }
 }
 
 impl ByteParser<()> for PlatformInfo {
+    type Bytes = [u8; 8];
+    const EXPECTED_LEN: Option<usize> = Some(8);
+}
+
+impl ByteParser<Version> for PlatformInfo {
     type Bytes = [u8; 8];
     const EXPECTED_LEN: Option<usize> = Some(8);
 }
@@ -1131,6 +1498,108 @@ bitfield! {
 
 }
 
+impl KeyInfo {
+    // Bits 0..4 are defined, bits 5..31 must be zero.
+    const RESERVED_MASK: u32 = !0x1F; // 0xFFFF_FFE0
+
+    // Bit 1: MASK_CHIP_KEY (added in v1.53)
+    const MASK_CHIP_KEY_BIT_1: u32 = 1u32 << 1;
+
+    // SIGNING_KEY field: bits 2-4
+    const SIGNING_KEY_MASK: u32 = 0b111 << 2;
+
+    // Version constants
+    const VERSION_1_53: Version = Version {
+        major: 1,
+        minor: 53,
+        build: 0,
+    };
+    const VERSION_1_54: Version = Version {
+        major: 1,
+        minor: 54,
+        build: 0,
+    };
+
+    fn validate_reserved_bits(self, version: Version) -> std::io::Result<()> {
+        let raw: u32 = self.0;
+
+        // Bits 5-31 must always be zero
+        if (raw & Self::RESERVED_MASK) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("KeyInfo reserved bits 5-31 must be zero (raw=0x{raw:08x})"),
+            ));
+        }
+
+        // Bit 1 (MASK_CHIP_KEY) is only defined for firmware v1.53+
+        if version < Self::VERSION_1_53 && (raw & Self::MASK_CHIP_KEY_BIT_1) != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "KeyInfo bit 1 (MASK_CHIP_KEY) is only valid for firmware v1.53+ (raw=0x{raw:08x})"
+                ),
+            ));
+        }
+
+        // SIGNING_KEY = VLEK (value 1) is only defined for firmware v1.54+
+        let signing_key = (raw & Self::SIGNING_KEY_MASK) >> 2;
+        if version < Self::VERSION_1_54 && signing_key == 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "KeyInfo SIGNING_KEY=VLEK (1) is only valid for firmware v1.54+ (raw=0x{raw:08x})"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Formats the key info with version-aware display.
+    ///
+    /// Key info fields that are not defined for the given firmware version
+    /// will be displayed as "None" instead of their actual value.
+    ///
+    /// # Arguments
+    /// * `version` - The firmware version to use for determining which fields are valid
+    ///
+    /// # Returns
+    /// A formatted string representation of the key info
+    pub fn display_for_version(&self, version: Version) -> String {
+        let mask_chip_key = if version >= Self::VERSION_1_53 {
+            format!("{}", self.mask_chip_key())
+        } else {
+            "None".to_string()
+        };
+
+        let signing_key = if version >= Self::VERSION_1_54 {
+            match self.signing_key() {
+                0 => "vcek".to_string(),
+                1 => "vlek".to_string(),
+                7 => "none".to_string(),
+                v => format!("unknown ({v})"),
+            }
+        } else {
+            // Pre v1.54 only supports VCEK (0) and NONE (7)
+            match self.signing_key() {
+                0 => "vcek".to_string(),
+                7 => "none".to_string(),
+                v => format!("unknown ({v})"),
+            }
+        };
+
+        format!(
+            r#"Key Information:
+    author key enabled: {}
+    mask chip key:      {}
+    signing key:        {}"#,
+            self.author_key_en(),
+            mask_chip_key,
+            signing_key
+        )
+    }
+}
+
 impl Encoder<()> for KeyInfo {
     fn encode(&self, writer: &mut impl Write, _: ()) -> Result<(), std::io::Error> {
         writer.write_bytes(self.0.to_le_bytes(), ())?;
@@ -1138,14 +1607,30 @@ impl Encoder<()> for KeyInfo {
     }
 }
 
+// No checking in case key info is being parsed outside attestation report
 impl Decoder<()> for KeyInfo {
     fn decode(reader: &mut impl Read, _: ()) -> Result<Self, std::io::Error> {
-        let info = reader.read_bytes()?;
-        Ok(Self(info))
+        let raw: u32 = reader.read_bytes()?;
+        Ok(KeyInfo(raw))
+    }
+}
+
+// Checking reserved bytes according to known reserved bytes in attestation report
+impl Decoder<Version> for KeyInfo {
+    fn decode(reader: &mut impl Read, version: Version) -> Result<Self, std::io::Error> {
+        let raw: u32 = reader.read_bytes()?;
+        let info = KeyInfo(raw);
+        info.validate_reserved_bits(version)?;
+        Ok(info)
     }
 }
 
 impl ByteParser<()> for KeyInfo {
+    type Bytes = [u8; 4];
+    const EXPECTED_LEN: Option<usize> = Some(4);
+}
+
+impl ByteParser<Version> for KeyInfo {
     type Bytes = [u8; 4];
     const EXPECTED_LEN: Option<usize> = Some(4);
 }
@@ -1264,6 +1749,10 @@ mod tests {
         // sig algo
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
+
         // Make chip_id non-zero so v2 parsing doesn't error out
         bytes[CHIP_ID_RANGE.start] = 1;
 
@@ -1276,18 +1765,18 @@ Version:                      V2
 
 Guest SVN:                    0
 
-Guest Policy (0x0):
-  ABI Major:     0
-  ABI Minor:     0
-  SMT Allowed:   false
-  Migrate MA:    false
-  Debug Allowed: false
-  Single Socket: false
-  CXL Allowed:   false
-  AEX 256 XTS:   false
-  RAPL Allowed:  false
-  Ciphertext hiding: false
-  Page Swap Disable: false
+Guest Policy (0x20000):
+  ABI Major:         0
+  ABI Minor:         0
+  SMT Allowed:       false
+  Migrate MA:        false
+  Debug Allowed:     false
+  Single Socket:     false
+  CXL Allowed:       None
+  AES 256 XTS:       None
+  RAPL Disabled:     None
+  Ciphertext Hiding: None
+  Page Swap Disable: None
 
 Family ID:
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -1311,15 +1800,15 @@ TCB Version:
 Platform Info (0):
   SMT Enabled:               false
   TSME Enabled:              false
-  ECC Enabled:               false
-  RAPL Disabled:             false
-  Ciphertext Hiding Enabled: false
-  Alias Check Complete:      false
-  SEV-TIO Enabled:           false
+  ECC Enabled:               None
+  RAPL Disabled:             None
+  Ciphertext Hiding Enabled: None
+  Alias Check Complete:      None
+  SEV-TIO Enabled:           None
 
 Key Information:
     author key enabled: false
-    mask chip key:      false
+    mask chip key:      None
     signing key:        vcek
 
 Report Data:
@@ -1613,10 +2102,11 @@ Current Mitigation Vector:    None
 
     #[test]
     fn test_platform_info_v2_serialization() {
-        let original = PlatformInfo(0b11111);
-        // Test encoding and decoding
-        let buffer = original.to_bytes().unwrap();
-        let decoded = PlatformInfo::from_bytes(&buffer).unwrap();
+        let original = PlatformInfo(0b11);
+        // Test encoding and decoding with basic bits (SMT, TSME) only
+        let mut buffer = [0u8; 8];
+        original.encode(&mut buffer.as_mut_slice(), ()).unwrap();
+        let decoded = PlatformInfo::decode(&mut buffer.as_slice(), ()).unwrap();
 
         assert_eq!(original, decoded);
     }
@@ -1626,8 +2116,9 @@ Current Mitigation Vector:    None
         let original = KeyInfo(0b11111);
 
         // Test encoding and decoding
-        let buffer = original.to_bytes().unwrap();
-        let decoded = KeyInfo::from_bytes(&buffer).unwrap();
+        let mut buffer = [0u8; 4];
+        original.encode(&mut buffer.as_mut_slice(), ()).unwrap();
+        let decoded = KeyInfo::decode(&mut buffer.as_slice(), ()).unwrap();
 
         assert_eq!(original, decoded);
         assert!(decoded.author_key_en());
@@ -1637,14 +2128,15 @@ Current Mitigation Vector:    None
 
     #[test]
     fn test_guest_policy_serialization() {
-        let mut original: GuestPolicy = Default::default();
+        let mut original: GuestPolicy = GuestPolicy::from(0u64);
         original.set_abi_major(2);
         original.set_abi_minor(1);
         original.set_smt_allowed(true);
         original.set_debug_allowed(true);
 
         let buffer = original.to_bytes().unwrap();
-        let decoded = GuestPolicy::from_bytes(&buffer).unwrap();
+        // Use a recent firmware version that supports all policy bits
+        let decoded = GuestPolicy::from_bytes_with(&buffer, Version::new(1, 58, 0)).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -1657,28 +2149,6 @@ Current Mitigation Vector:    None
         let raw_v3 = [3, 0, 0, 0]; // Version 3
         let version = u32::from_le_bytes([raw_v3[0], raw_v3[1], raw_v3[2], raw_v3[3]]);
         assert_eq!(version, 3);
-    }
-
-    #[test]
-    fn test_boundary_value_serialization() {
-        // Test max values
-        let platform_info = PlatformInfo(u64::MAX);
-        let key_info = KeyInfo(u32::MAX);
-        let guest_policy = GuestPolicy(u64::MAX);
-
-        // Verify serialization/deserialization preserves max values
-        assert_eq!(
-            platform_info,
-            PlatformInfo::from_bytes(&platform_info.to_bytes().unwrap()).unwrap()
-        );
-        assert_eq!(
-            key_info,
-            KeyInfo::from_bytes(&key_info.to_bytes().unwrap()).unwrap()
-        );
-        assert_eq!(
-            guest_policy,
-            GuestPolicy::from_bytes(&guest_policy.to_bytes().unwrap()).unwrap()
-        );
     }
 
     #[test]
@@ -1740,8 +2210,12 @@ Current Mitigation Vector:    None
         // vmpl at 0x30..0x34
         bytes[0x30..0x34].copy_from_slice(&3u32.to_le_bytes());
 
-        // signature alorithm
+        // signature algorithm
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
 
         let report = Report::from_bytes(&bytes).unwrap();
 
@@ -1813,8 +2287,12 @@ Current Mitigation Vector:    None
         bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
         bytes[CHIP_ID_RANGE.start] = 1; // unmask chip id
 
-        // signature alorithm
+        // signature algorithm
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
 
         let report = Report::from_bytes(bytes.as_slice());
         assert!(report.is_ok());
@@ -1844,7 +2322,12 @@ Current Mitigation Vector:    None
         // guest_svn
         bytes[0x04..0x08].copy_from_slice(&1u32.to_le_bytes());
 
+        // signature algorithm
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
 
         let report = Report::from_bytes(&bytes).unwrap();
         let body = ReportBody::from_bytes(report.body).unwrap();
@@ -1967,6 +2450,10 @@ Current Mitigation Vector:    None
 
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
+
         bytes[CHIP_ID_RANGE.clone()].copy_from_slice(&vcek_bytes);
 
         let report = Report::from_bytes(&bytes).unwrap();
@@ -1993,6 +2480,10 @@ Current Mitigation Vector:    None
 
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
+        // policy u64 LE at 0x08..0x10
+        let policy_raw = 1u64 << 17; // RMB1 bit
+        bytes[0x08..0x10].copy_from_slice(&policy_raw.to_le_bytes());
+
         let report = Report::from_bytes(&bytes).unwrap();
         let body = ReportBody::from_bytes(report.body).unwrap();
 
@@ -2017,7 +2508,7 @@ Current Mitigation Vector:    None
     fn test_report_from_bytes_splits_body_and_signature() {
         let mut bytes = vec![0u8; Report::REPORT_LEN];
 
-        // signature alorithm
+        // signature algorithm
         bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
         let r = Report::from_bytes(&bytes).unwrap();

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
-use crate::certs::snp::{ecdsa::Signature, Certificate, Chain, Verifiable};
+use crate::certs::snp::{Certificate, Chain, Verifiable};
 
 use crate::{
+    certs::snp::signature::SignatureAlgorithm,
     firmware::host::TcbVersion,
     parser::{ByteParser, Decoder, Encoder},
     util::{
@@ -24,13 +25,7 @@ use std::{
     io::{Read, Write},
 };
 
-#[cfg(feature = "openssl")]
-use std::io::Error;
-
 use bitfield::bitfield;
-
-#[cfg(feature = "openssl")]
-use openssl::{ecdsa::EcdsaSig, sha::Sha384};
 
 /// Structure of required data for fetching the derived key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -345,6 +340,8 @@ impl Display for ReportVariant {
 ///   firmware report layout and size (1184 bytes).
 #[derive(Debug, Clone, Copy)]
 pub struct Report<'a> {
+    /// The signature algorithm used to sign the attestation report
+    pub algorithm: SignatureAlgorithm,
     /// The bytes covered by the report signature (bytes 0x00 to 0x2A0).
     pub body: &'a [u8],
     /// The signature bytes (0x2A0..0x4A0).
@@ -356,6 +353,8 @@ impl<'a> Report<'a> {
     const BODY_LEN: usize = 0x2A0; // bytes 0x000..=0x29F
     const SIG_OFF: usize = 0x2A0;
     const SIG_LEN: usize = 0x200; // bytes 0x2A0..=0x49F
+    const SIG_ALGO_OFF: usize = 0x34;
+    const SIG_ALGO_LEN: usize = 0x4;
     /// Parse a raw attestation report into body and signature slices.
     ///
     /// This function performs **framing only**:
@@ -373,68 +372,29 @@ impl<'a> Report<'a> {
             ));
         };
 
+        let algorithm = SignatureAlgorithm::decode(
+            &mut &report[Self::SIG_ALGO_OFF..Self::SIG_ALGO_OFF + Self::SIG_ALGO_LEN],
+            (),
+        )?;
+
         Ok(Self {
+            algorithm,
             body: &report[..Self::BODY_LEN],
             signature: &report[Self::SIG_OFF..Self::SIG_OFF + Self::SIG_LEN],
         })
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "crypto_nossl"))]
 impl Verifiable for (&Certificate, &Report<'_>) {
     type Output = ();
 
-    fn verify(self) -> std::io::Result<Self::Output> {
+    fn verify(self) -> Result<Self::Output, std::io::Error> {
         let (vek, report) = self;
 
-        let sev_sig = Signature::from_bytes(report.signature)?;
+        let algo = report.algorithm;
 
-        let sig: EcdsaSig = EcdsaSig::try_from(&sev_sig)?;
-
-        let mut hasher = Sha384::new();
-        hasher.update(report.body);
-        let base_digest = hasher.finish();
-
-        let ec = vek.public_key()?.ec_key()?;
-        let signed = sig.verify(&base_digest, &ec)?;
-        match signed {
-            true => Ok(()),
-            false => Err(Error::other("VEK does not sign the attestation report")),
-        }
-    }
-}
-
-#[cfg(feature = "crypto_nossl")]
-impl Verifiable for (&Certificate, &Report<'_>) {
-    type Output = ();
-
-    fn verify(self) -> std::io::Result<Self::Output> {
-        // According to Chapter 3 of the Versioned Chip Endorsement Key (VCEK) Certificate and the Versioned Loaded Endorsement Key (VLEK)
-        // Certificate specifications, both Versioned Endorsement Key certificates certify an ECDSA public key on curve P-384,
-        // with the signature hash algorithm being SHA-384.
-
-        let (vek, report) = self;
-
-        let sev_sig = Signature::from_bytes(report.signature)?;
-
-        let sig = p384::ecdsa::Signature::try_from(&sev_sig).map_err(|e| {
-            std::io::Error::other(format!(
-                "failed to generate signature from raw bytes: {e:?}"
-            ))
-        })?;
-
-        use sha2::Digest;
-        let base_digest = sha2::Sha384::new_with_prefix(report.body);
-        let verifying_key = p384::ecdsa::VerifyingKey::from_sec1_bytes(vek.public_key_sec1())
-            .map_err(|e| {
-                std::io::Error::other(format!(
-                    "failed to deserialize public key from sec1 bytes: {e:?}"
-                ))
-            })?;
-        use p384::ecdsa::signature::DigestVerifier;
-        verifying_key.verify_digest(base_digest, &sig).map_err(|e| {
-            std::io::Error::other(format!("VEK does not sign the attestation report: {e:?}"))
-        })
+        (algo, report.body, report.signature, vek).verify()
     }
 }
 
@@ -442,7 +402,7 @@ impl Verifiable for (&Certificate, &Report<'_>) {
 impl Verifiable for (&Chain, &Report<'_>) {
     type Output = ();
 
-    fn verify(self) -> std::io::Result<()> {
+    fn verify(self) -> Result<(), std::io::Error> {
         let (chain, report) = self;
         let vek = chain.verify()?;
         (vek, report).verify()
@@ -511,7 +471,7 @@ pub struct ReportBody<'a> {
     pub vmpl: u32,
 
     /// Signature algorithm used to sign this report.
-    pub sig_algo: u32,
+    pub sig_algo: SignatureAlgorithm,
 
     /// Current TCB (Trusted Computing Base) version, parsed for the inferred generation.
     pub current_tcb: TcbVersion,
@@ -699,7 +659,7 @@ impl<'a> ReportBody<'a> {
 
         let vmpl = u32::decode(&mut &body[0x30..0x34], ())?;
 
-        let sig_algo = u32::decode(&mut &body[0x34..0x38], ())?;
+        let sig_algo = SignatureAlgorithm::decode(&mut &body[0x34..0x38], ())?;
 
         let current_tcb = TcbVersion::decode(&mut &body[0x38..0x40], generation)?;
 
@@ -1301,6 +1261,9 @@ mod tests {
         // version: u32 LE at 0x00..0x04
         bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes());
 
+        // sig algo
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         // Make chip_id non-zero so v2 parsing doesn't error out
         bytes[CHIP_ID_RANGE.start] = 1;
 
@@ -1334,7 +1297,7 @@ Image ID:
 
 VMPL:                         0
 
-Signature Algorithm:          0
+Signature Algorithm:          ECDSA with SECP384R1
 
 Current TCB:
 
@@ -1445,7 +1408,11 @@ Current Mitigation Vector:    None
 
     #[test]
     fn test_report_copy() {
-        let bytes = vec![0u8; Report::REPORT_LEN];
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+
+        // Setting sig algo
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let report = Report::from_bytes(&bytes).unwrap();
         let copy = report;
 
@@ -1676,7 +1643,6 @@ Current Mitigation Vector:    None
         original.set_smt_allowed(true);
         original.set_debug_allowed(true);
 
-        // Test bincode
         let buffer = original.to_bytes().unwrap();
         let decoded = GuestPolicy::from_bytes(&buffer).unwrap();
         assert_eq!(original, decoded);
@@ -1774,6 +1740,9 @@ Current Mitigation Vector:    None
         // vmpl at 0x30..0x34
         bytes[0x30..0x34].copy_from_slice(&3u32.to_le_bytes());
 
+        // signature alorithm
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let report = Report::from_bytes(&bytes).unwrap();
 
         // NOTE: parsing-only test: do NOT use TryFrom/verify path here
@@ -1783,6 +1752,7 @@ Current Mitigation Vector:    None
         assert_eq!(body.guest_svn, 1);
         assert_eq!(body.vmpl, 3);
         assert_eq!(body.measurement, &[0u8; 48]);
+        assert_eq!(body.sig_algo, SignatureAlgorithm::EcdsaSecp384r1)
     }
 
     #[test]
@@ -1843,6 +1813,9 @@ Current Mitigation Vector:    None
         bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
         bytes[CHIP_ID_RANGE.start] = 1; // unmask chip id
 
+        // signature alorithm
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let report = Report::from_bytes(bytes.as_slice());
         assert!(report.is_ok());
 
@@ -1870,6 +1843,8 @@ Current Mitigation Vector:    None
 
         // guest_svn
         bytes[0x04..0x08].copy_from_slice(&1u32.to_le_bytes());
+
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
         let report = Report::from_bytes(&bytes).unwrap();
         let body = ReportBody::from_bytes(report.body).unwrap();
@@ -1989,6 +1964,9 @@ Current Mitigation Vector:    None
             0x0E, 0xFA, 0xCF, 0xD0, 0x8E, 0x24, 0x43, 0x24, 0x88, 0x47, 0x38, 0xC7, 0x2B, 0x08,
             0x2E, 0x2F, 0x87, 0xA4, 0x4D, 0x54, 0x1E, 0xB6,
         ];
+
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         bytes[CHIP_ID_RANGE.clone()].copy_from_slice(&vcek_bytes);
 
         let report = Report::from_bytes(&bytes).unwrap();
@@ -2013,6 +1991,8 @@ Current Mitigation Vector:    None
         // rest remains zero
         bytes[CHIP_ID_RANGE.clone()].copy_from_slice(&chip);
 
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let report = Report::from_bytes(&bytes).unwrap();
         let body = ReportBody::from_bytes(report.body).unwrap();
 
@@ -2025,6 +2005,9 @@ Current Mitigation Vector:    None
         bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes()); // v2
                                                                 // chip_id left as all zeros
 
+        // Setting sig algo
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let report = Report::from_bytes(&bytes).unwrap();
         let err = ReportBody::from_bytes(report.body).unwrap_err();
         assert!(err.to_string().contains("Chip ID is masked"));
@@ -2032,11 +2015,15 @@ Current Mitigation Vector:    None
 
     #[test]
     fn test_report_from_bytes_splits_body_and_signature() {
-        let bytes = vec![0u8; Report::REPORT_LEN];
+        let mut bytes = vec![0u8; Report::REPORT_LEN];
+
+        // signature alorithm
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
+
         let r = Report::from_bytes(&bytes).unwrap();
 
         assert_eq!(r.body.len(), 0x2a0);
-        assert_eq!(r.signature.len(), 0x49f - 0x2a0);
+        assert_eq!(r.signature.len(), 0x49f + 1 - 0x2a0);
         assert_eq!(r.body.as_ptr(), bytes.as_ptr());
         assert_eq!(
             r.signature.as_ptr() as usize - bytes.as_ptr() as usize,
@@ -2058,6 +2045,9 @@ Current Mitigation Vector:    None
         let mut bytes = vec![0u8; Report::REPORT_LEN];
         bytes[0x00..0x04].copy_from_slice(&2u32.to_le_bytes());
         bytes[CHIP_ID_RANGE.start] = 1;
+
+        // Setting sig algo
+        bytes[0x34..0x38].copy_from_slice(&1u32.to_le_bytes());
 
         bytes[0x4C] = 1; // reserved byte non-zero
 

--- a/src/firmware/host/types/snp.rs
+++ b/src/firmware/host/types/snp.rs
@@ -10,7 +10,7 @@ use crate::{
     parser::{ByteParser, Decoder, Encoder},
     util::{
         hexline::HexLine,
-        parser_helper::{ReadExt, WriteExt},
+        parser_helper::{validate_reserved, ReadExt, WriteExt},
     },
     Generation,
 };
@@ -495,6 +495,34 @@ impl TryFrom<FFI::types::SnpSetConfig> for Config {
     }
 }
 
+/// Internal selector for known serialized TCB version layouts.
+///
+/// The TCB version is encoded as an 8-byte value, but the meaning of each byte
+/// depends on the [`Generation`] of the host CPU.
+///
+/// - [`TcbVariant::LegacyTcb`] is used for Milan and Genoa.
+/// - [`TcbVariant::TurinTcb`] is used for Turin and Venice.
+pub(crate) enum TcbVariant {
+    /// Legacy TCB version layout.
+    ///
+    /// - byte 0: bootloader SVN
+    /// - byte 1: PSP OS / TEE SVN
+    /// - bytes 2..6: reserved
+    /// - byte 6: SNP firmware SVN
+    /// - byte 7: microcode SVN
+    LegacyTcb,
+
+    /// Turin-style TCB version layout.
+    ///
+    /// - byte 0: FMC firmware SVN
+    /// - byte 1: bootloader SVN
+    /// - byte 2: PSP OS / TEE SVN
+    /// - byte 3: SNP firmware SVN
+    /// - bytes 4..7: reserved
+    /// - byte 7: microcode SVN
+    TurinTcb,
+}
+
 /// TcbVersion represents the version of the firmware.
 ///
 /// (Chapter 2.2; Table 3)
@@ -516,6 +544,36 @@ pub struct TcbVersion {
     pub snp: u8,
     /// Lowest current patch level of all the cores.
     pub microcode: u8,
+}
+
+impl TryFrom<(&[u8], TcbVariant)> for TcbVersion {
+    type Error = std::io::Error;
+
+    fn try_from(value: (&[u8], TcbVariant)) -> Result<Self, std::io::Error> {
+        let (bytes, variant) = value;
+        match variant {
+            TcbVariant::LegacyTcb => {
+                validate_reserved(&bytes[2..6], 2)?;
+                Ok(Self {
+                    fmc: None,
+                    bootloader: bytes[0],
+                    tee: bytes[1],
+                    snp: bytes[6],
+                    microcode: bytes[7],
+                })
+            }
+            TcbVariant::TurinTcb => {
+                validate_reserved(&bytes[4..7], 4)?;
+                Ok(Self {
+                    fmc: Some(bytes[0]),
+                    bootloader: bytes[1],
+                    tee: bytes[2],
+                    snp: bytes[3],
+                    microcode: bytes[7],
+                })
+            }
+        }
+    }
 }
 
 impl Encoder<Generation> for TcbVersion {
@@ -541,12 +599,13 @@ impl Encoder<Generation> for TcbVersion {
 
 impl Decoder<Generation> for TcbVersion {
     fn decode(reader: &mut impl Read, generation: Generation) -> Result<Self, std::io::Error> {
+        let bytes: [u8; 8] = reader.read_bytes()?;
         match generation {
             Generation::Milan | Generation::Genoa => {
-                Ok(TcbVersion::from_legacy_bytes(&reader.read_bytes()?))
+                TcbVersion::try_from((bytes.as_slice(), TcbVariant::LegacyTcb))
             }
             Generation::Turin | Generation::Venice => {
-                Ok(TcbVersion::from_turin_bytes(&reader.read_bytes()?))
+                TcbVersion::try_from((bytes.as_slice(), TcbVariant::TurinTcb))
             }
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
@@ -562,16 +621,6 @@ impl ByteParser<Generation> for TcbVersion {
 }
 
 impl TcbVersion {
-    pub(crate) fn from_legacy_bytes(bytes: &[u8; 8]) -> Self {
-        Self {
-            fmc: None,
-            bootloader: bytes[0],
-            tee: bytes[1],
-            snp: bytes[6],
-            microcode: bytes[7],
-        }
-    }
-
     pub(crate) fn to_legacy_bytes(self) -> [u8; 8] {
         [
             self.bootloader,
@@ -583,16 +632,6 @@ impl TcbVersion {
             self.snp,
             self.microcode,
         ]
-    }
-
-    pub(crate) fn from_turin_bytes(bytes: &[u8; 8]) -> Self {
-        Self {
-            fmc: Some(bytes[0]),
-            bootloader: bytes[1],
-            tee: bytes[2],
-            snp: bytes[3],
-            microcode: bytes[7],
-        }
     }
 
     pub(crate) fn to_turin_bytes(self) -> [u8; 8] {
@@ -1488,7 +1527,8 @@ mod tests {
         let tcb = TcbVersion::new(None, 1, 2, 3, 4);
 
         let serialized = tcb.to_legacy_bytes();
-        let deserialized = TcbVersion::from_legacy_bytes(&serialized);
+        let deserialized =
+            TcbVersion::try_from((serialized.as_slice(), TcbVariant::LegacyTcb)).unwrap();
 
         assert_eq!(tcb, deserialized);
     }

--- a/src/util/parser_helper/mod.rs
+++ b/src/util/parser_helper/mod.rs
@@ -4,6 +4,10 @@ mod read_ext;
 
 mod write_ext;
 
+mod reserved;
+
 pub(crate) use read_ext::ReadExt;
 
 pub(crate) use write_ext::WriteExt;
+
+pub(crate) use reserved::validate_reserved;

--- a/src/util/parser_helper/reserved.rs
+++ b/src/util/parser_helper/reserved.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// Validates that reserved bytes at a known offset are all zero.
+///
+/// This function checks that all bytes in the provided slice contain only zeros,
+/// which is required by the SNP attestation report specification for reserved fields.
+///
+/// # Arguments
+///
+/// * `reserved` - A byte slice containing the reserved bytes to validate
+/// * `offset` - The starting offset of the slice in the original buffer (for error messages)
+///
+/// # Returns
+///
+/// Returns `Ok(())` if all bytes in the slice are zero, or an `Err` with a descriptive
+/// message if any reserved byte is non-zero, including the absolute offset.
+///
+/// # Errors
+///
+/// Returns an error if any byte in the slice is non-zero, including the absolute offsets
+/// and values of the non-zero bytes.
+///
+/// # Example
+///
+/// ```ignore
+/// let body = &buffer[0..0x2A0];
+/// validate_reserved(&body[0x4C..0x50], 0x4C)?; // Reports absolute offsets 0x4C-0x4F
+/// ```
+pub fn validate_reserved(reserved: &[u8], offset: usize) -> Result<(), std::io::Error> {
+    // Collect indices and values of non-zero bytes
+    let non_zero: Vec<(usize, u8)> = reserved
+        .iter()
+        .enumerate()
+        .filter(|(_, &b)| b != 0)
+        .map(|(i, &b)| (offset + i, b))
+        .collect();
+
+    if !non_zero.is_empty() {
+        // Format the non-zero bytes for the error message with absolute offsets
+        let details: Vec<String> = non_zero
+            .iter()
+            .map(|(idx, val)| format!("[0x{:x}]=0x{:02x}", idx, val))
+            .collect();
+
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("reserved bytes are non-zero: {}", details.join(", ")),
+        ));
+    }
+
+    Ok(())
+}

--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -25,8 +25,9 @@ mod sev {
 #[cfg(all(feature = "snp", any(feature = "openssl", feature = "crypto_nossl")))]
 mod snp {
 
+    use std::convert::TryFrom;
+
     use sev::certs::snp::{builtin::milan, ca, Certificate, Chain, Verifiable};
-    use sev::parser::ByteParser;
 
     const TEST_MILAN_VCEK_DER: &[u8] = include_bytes!("certs_data/vcek_milan.der");
 
@@ -76,7 +77,7 @@ mod snp {
 
     #[test]
     fn milan_report() {
-        use sev::firmware::guest::AttestationReport;
+        use sev::firmware::guest::{Report, ReportBody};
 
         let ark = milan::ark().unwrap();
         let ask = milan::ask().unwrap();
@@ -87,14 +88,18 @@ mod snp {
         let chain = Chain { ca, vek: vcek };
 
         let report_bytes = hex::decode(TEST_MILAN_ATTESTATION_REPORT).unwrap();
-        let report = AttestationReport::from_bytes(report_bytes.as_slice()).unwrap();
-
-        assert_eq!((&chain, &report).verify().ok(), Some(()));
+        let report = Report::from_bytes(report_bytes.as_slice()).unwrap();
+        let _body = ReportBody::try_from((&report, &chain))
+            .map_err(|e| {
+                println!("report verification failed: {e}");
+                e
+            })
+            .unwrap();
     }
 
     #[test]
     fn milan_report_invalid() {
-        use sev::firmware::guest::AttestationReport;
+        use sev::firmware::guest::{Report, ReportBody};
 
         let ark = milan::ark().unwrap();
         let ask = milan::ask().unwrap();
@@ -106,9 +111,8 @@ mod snp {
 
         let mut report_bytes = hex::decode(TEST_MILAN_ATTESTATION_REPORT).unwrap();
         report_bytes[21] ^= 0x80;
-        let report = AttestationReport::from_bytes(report_bytes.as_slice()).unwrap();
-
-        assert_eq!((&chain, &report).verify().ok(), None);
+        let report = Report::from_bytes(report_bytes.as_slice()).unwrap();
+        assert!(ReportBody::try_from((&report, &chain)).is_err());
     }
 
     #[cfg(feature = "openssl")]


### PR DESCRIPTION
## Overview

This PR implements a new SEV-SNP attestation report parsing flow, based on the discussion in  
https://github.com/virtee/sev/discussions/373.

The goal is to make it difficult to accidentally treat untrusted bytes as a verified report body, while still supporting efficient, zero-copy parsing and forward-compatible handling of newer firmware layouts.

---

## What’s in this PR

### 1) `Report`: a zero-copy view of an *unverified* attestation report

`Report` borrows the raw report buffer and exposes the relevant slices:

- `body`: the signed portion of the report
- `signature`: the report signature bytes

`Report` is intentionally **not trusted**. It is only a framing layer that allows:

- Preserving the raw firmware report exactly as received
- Passing reports between intermediaries without parsing
- Performing signature verification without interpreting untrusted fields
- Maintaining forward compatibility for future report versions

---

### 2) `ReportBody`: a zero-copy, typed view of the report body

`ReportBody` parses the body into strongly typed fields while borrowing fixed-size arrays directly from the original buffer.
`ReportBody::from_bytes()` performs **no cryptographic verification**. It only validates structural layout and reserved fields.

The correct and safe way to obtain a `ReportBody` is via:

```rust
let report = Report::from_bytes(&raw_bytes)?;
let body = ReportBody::try_from((&report, &certificate_or_chain))?;
```

### The `TryFrom` Implementation

The `TryFrom` implementation:

- Verifies the report signature using the provided VEK or certificate chain.
- Only after successful verification, parses the signed body into a typed `ReportBody`.

This ensures all parsed fields are cryptographically authenticated.

---

### 3) `SignatureAlgorithm`: Single Entrypoint for Report Verification

This PR introduces a `SignatureAlgorithm` enum and makes it the single dispatch point for attestation report signature verification.

Changes include:

- Parsing the signature algorithm from `0x34..0x38` into `SignatureAlgorithm`
- Storing it in `Report`
- Delegating verification in `Verifiable for (&Certificate, &Report)` to:
```rust
SignatureAlgorithm::verify(body, signature, vek)
```
- Removing backend-specific hashing and signature conversion logic from firmware parsing code

This cleanly separates:
- Report layout/parsing
- Cryptographic verification logic

### 4) Spec-Driven Reserved/MBZ Validation and Stricter Parsing
Reserved-field handling is tightened to match the SNP ABI:
`GuestPolicy`
- Enforces RMB1 bit 17
- Validates MBZ (must-be-zero) reserved ranges

`PlatformInfo`
- Validates reserved bits

`TCB`
- Parsing updated to align strictly with generation-aware layouts
- Invalid reserved fields now fail early instead of being silently accepted.

### Intended Flow

```Plain Text
raw bytes
   ↓
Report::from_bytes (framing only)
   ↓  (signature verification via Certificate or Chain)
ReportBody::try_from((&report, &vek_or_chain))
   ↓
typed, verified ReportBody
```

### Forward Compatibility and Safety
This design:
- Preserves full raw report bytes
- Avoids lossy parsing of unknown or reserved fields
- Prevents unsafe coercion of future report versions
- Makes cryptographic verification explicit and centralized
- Ensures spec violations (reserved bits, MBZ fields, etc.) fail loudly