### PR TITLE
Support sev-snp measurement under crypto_nossl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,10 @@ pub mod certs;
 
 pub mod firmware;
 pub mod launch;
-#[cfg(all(any(feature = "sev", feature = "snp"), feature = "openssl"))]
+#[cfg(all(
+    any(feature = "sev", feature = "snp"),
+    any(feature = "openssl", feature = "crypto_nossl")
+))]
 pub mod measurement;
 #[cfg(all(target_os = "linux", feature = "openssl", feature = "sev"))]
 pub mod session;

--- a/src/measurement/gctx.rs
+++ b/src/measurement/gctx.rs
@@ -2,7 +2,17 @@
 //! Operations to handle and create a Guest Context
 use std::convert::TryInto;
 
+#[cfg(feature = "openssl")]
 use openssl::sha::sha384;
+
+#[cfg(feature = "crypto_nossl")]
+fn sha384(data: &[u8]) -> [u8; 48] {
+    use sha2::Digest;
+    let hash = sha2::Sha384::digest(data);
+    let mut out = [0u8; 48];
+    out.copy_from_slice(&hash);
+    out
+}
 
 use crate::{
     error::*,

--- a/src/measurement/mod.rs
+++ b/src/measurement/mod.rs
@@ -3,7 +3,7 @@
 //! Everything one needs to calculate a launch measurement for a SEV encrypted confidential guest.
 //! This includes, GCTX, SEV-HASHES, VMSA and OVMF pages.
 
-#[cfg(all(feature = "snp", feature = "openssl"))]
+#[cfg(all(feature = "snp", any(feature = "openssl", feature = "crypto_nossl")))]
 pub mod gctx;
 
 #[cfg(any(feature = "sev", feature = "snp"))]
@@ -12,13 +12,16 @@ pub mod ovmf;
 #[cfg(any(feature = "sev", feature = "snp"))]
 pub mod vmsa;
 
-#[cfg(all(any(feature = "sev", feature = "snp"), feature = "openssl"))]
+#[cfg(all(
+    any(feature = "sev", feature = "snp"),
+    any(feature = "openssl", feature = "crypto_nossl")
+))]
 pub mod sev_hashes;
 
 #[cfg(any(feature = "sev", feature = "snp"))]
 pub mod vcpu_types;
 
-#[cfg(all(feature = "snp", feature = "openssl"))]
+#[cfg(all(feature = "snp", any(feature = "openssl", feature = "crypto_nossl")))]
 pub mod snp;
 
 #[cfg(all(feature = "sev", feature = "openssl"))]

--- a/src/measurement/sev_hashes.rs
+++ b/src/measurement/sev_hashes.rs
@@ -1,7 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Operations to handle OVMF SEV-HASHES
+#[cfg(feature = "openssl")]
 use openssl::sha::sha256;
+
+#[cfg(feature = "crypto_nossl")]
+fn sha256(data: &[u8]) -> [u8; 32] {
+    use sha2::Digest;
+    let hash = sha2::Sha256::digest(data);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hash);
+    out
+}
 use std::fs::File;
 use std::io::Write;
 use std::{


### PR DESCRIPTION
None of the measurement functionality was supported under the `crypto_nossl` feature.

This adds support where doing so is trivial (including `snp_calc_launch_digest`, which I needed) but does not add support for functionality that required more substantial changes.