### PR TITLE
docs: announce upcoming SNP attestation report API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sev"
-version = "7.1.0"
+version = "8.0.0"
 authors = [
     "Nathaniel McCallum <npmccallum@redhat.com>",
     "The VirTEE Project Developers",

--- a/src/firmware/guest/types/snp.rs
+++ b/src/firmware/guest/types/snp.rs
@@ -240,6 +240,15 @@ impl ByteParser<()> for ReportVariant {
 /// The launch_mit_vector and current_mit_vector fields
 /// The page_swap_disabled field in the GuestPolicy field
 /// The SEV-TIO field in the PlatformInfo field
+///
+/// # Compatibility notice
+///
+/// This legacy eager-parsing model will be replaced in the next breaking
+/// release by a two-stage attestation report API that separates unverified
+/// report framing from verified report-body parsing.
+///
+/// Code that depends directly on `AttestationReport` should expect to migrate
+/// in the next breaking release.
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Mark the eager SNP attestation report parsing API as deprecated ahead of the upcoming two-stage Report -> ReportBody parsing flow.

The new flow will separate unverified report framing from typed report body parsing after signature verification.

Would like to merge this deprecation status before cutting the new release.

Do you think it's necessary @tylerfanelli @larrydewey 