### PR TITLE
ci: pin cargo-rdme 1.4.8 so the README check stays on 1.85

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
+          toolchain: 1.85.0
       - run: |
-          cargo install cargo-rdme
+          cargo install cargo-rdme --version 1.4.8 --locked
           cargo rdme --check
 
   check-spdx-headers:


### PR DESCRIPTION
Latest cargo-rdme needs a pinned nightly for rustdoc JSON, which broke the job.